### PR TITLE
Fix double quote bug in song names

### DIFF
--- a/lib/music.rb
+++ b/lib/music.rb
@@ -2,19 +2,17 @@ require 'open3'
 require 'json'
 
 class Music
+  NULL_RESPONSE = "null|null|null"
 
   SAFE_MUSIC_SCRIPT = <<~APPLESCRIPT
     tell application "Music"
-      if not running then return "{\\\"name\\\":null,\\\"artist\\\":null,\\\"album\\\":null}"
-      if player state is stopped then return "{\\\"name\\\":null,\\\"artist\\\":null,\\\"album\\\":null}"
+      if not running then return "#{NULL_RESPONSE}"
+      if player state is stopped then return "#{NULL_RESPONSE}"
       try
         set t to current track
-        set n to name of t
-        set a to artist of t
-        set al to album of t
-        return "{\\\"name\\\":\\\"" & n & "\\\",\\\"artist\\\":\\\"" & a & "\\\",\\\"album\\\":\\\"" & al & "\\\"}"
+        return (name of t) & "|" & (artist of t) & "|" & (album of t)
       on error number -1728
-        return "{\\\"name\\\":null,\\\"artist\\\":null,\\\"album\\\":null}"
+        return "#{NULL_RESPONSE}"
       end try
     end tell
   APPLESCRIPT
@@ -24,9 +22,20 @@ class Music
     cmd += ["-l", lang] if lang
     cmd += ["-e", script]
     stdout, stderr, status = Open3.capture3(*cmd)
-    [JSON.parse(stdout.strip), stderr.strip, status.success?]
-    puts "⛔️ Could not get current track: #{stderr.strip}" unless status.success?
-    JSON.parse(stdout.strip, symbolize_names: true)
+    
+    unless status.success?
+      puts "⛔️ Could not get current track: #{stderr.strip}"
+      return { name: nil, artist: nil, album: nil }
+    end
+    
+    result = stdout.strip
+    parts = result.split("|")
+    
+    {
+      name: parts[0] == "null" ? nil : parts[0],
+      artist: parts[1] == "null" ? nil : parts[1], 
+      album: parts[2] == "null" ? nil : parts[2]
+    }
   end
 
   def playpause


### PR DESCRIPTION
Fixes issue where song names containing double quotes would break the Slack status update by replacing JSON construction in AppleScript with pipe-delimited format parsed in Ruby.