### PR TITLE
Multi-profile token resolution, OAuth setup flow, and emoji migration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+ruby "~> 3.0"
+
+# WEBrick was extracted from stdlib in Ruby 3.0; the OAuth helper boots a
+# one-shot listener on 127.0.0.1 to capture the Slack redirect.
+gem "webrick", "~> 1.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,17 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    webrick (1.9.2)
+
+PLATFORMS
+  arm64-darwin-23
+  ruby
+
+DEPENDENCIES
+  webrick (~> 1.8)
+
+RUBY VERSION
+   ruby 3.4.1p0
+
+BUNDLED WITH
+   2.6.2

--- a/README.md
+++ b/README.md
@@ -1,162 +1,42 @@
 # slack-status-cli
 
-A Ruby-based CLI tool for updating your Slack status with mythological flair and Apple Music integration ✨🎵
+A Ruby-based CLI for updating your Slack status with mythological flair and Apple Music integration ✨🎵
 
 ## Features
 
-- **Mythological Status**: Set random mythological beast emojis (wolf, lion, phoenix, fox, butterfly)
-- **Preset Modes**: Quick lunch and break statuses with auto-expiration
-- **Apple Music Integration**: Display currently playing track with mythological creatures
-- **Custom Status**: Set any custom message and emoji combination
-- **Auto-expiration**: Built-in support for temporary statuses
-- **Graceful Shutdown**: Clean status clearing on exit
+- **Mythological status emojis** with preset modes (`myth`, `lunch`, `break`, `clear`) — see [docs/usage.md](docs/usage.md).
+- **Apple Music / now-playing integration** with adaptive refresh cadence — see [docs/musical-myth.md](docs/musical-myth.md).
+- **Multi-profile token management** with Dashlane / Keychain / file / env backends and git-style global defaults — see [docs/security.md](docs/security.md).
+- **One-command OAuth setup** against a manifest-defined Slack App — see [docs/setup.md](docs/setup.md).
+- **`doctor` mode** that validates the resolved token via `auth.test` and decodes Slack-side errors — see [docs/troubleshooting.md](docs/troubleshooting.md).
 
-## 🛠️ Setup
-
-1. **Get your Slack user token (`xoxp-...`)**
-   - Create a Slack app at https://api.slack.com/apps
-   - Add the scope `users.profile:write`
-   - Install the app to your workspace and grab the token
-
-2. **Set it as an environment variable**:
-
-   ```bash
-   export SLACK_SECRET_TOKEN=xoxp-...
-   ```
-
-3. **Install `nowplaying-cli`** (required for `musical_myth`):
-
-   ```bash
-   brew install nowplaying-cli
-   ```
-
-   This is what `musical_myth` reads to pick up the currently playing track. If it's missing, the loop falls back to AppleScript against the native `Music.app`; if both fail, the status text falls back to `🔇 sound of silence`.
-
----
-
-## 🔥 Usage
+## Quickstart
 
 ```bash
-ruby slack_status.rb                        # Sets a random mythological beast emoji
-ruby slack_status.rb myth                   # Sets a random mythological beast emoji
-ruby slack_status.rb lunch                  # Sets lunch status (expires in 1 hour)
-ruby slack_status.rb break                  # Sets break status (expires in 30 minutes)
-ruby slack_status.rb clear                  # Clears the status
-ruby slack_status.rb musical_myth           # Continuously updates with the currently playing track
-ruby slack_status.rb custom "Custom message" ":fire:" [expiration_seconds]  # Custom status
+bundle install
+ruby slack_status.rb setup --profile personal   # walks you through OAuth + storage
+ruby slack_status.rb doctor --profile personal  # validates the token
+ruby slack_status.rb myth                       # flex a random mythological beast
 ```
 
-> Reserved first-arg modes are `myth`, `lunch`, `break`, `clear`, and `musical_myth`. Any other value (`custom`, `focus`, `""`, etc.) is treated as a custom status and the remaining args (`text`, `emoji`, `expiration_seconds`) take over.
+Full prerequisites (Ruby 3, `nowplaying-cli`, optional `dcli` for Dashlane) live in [docs/setup.md](docs/setup.md).
 
-### Musical Myth Mode
+## Documentation
 
-The `musical_myth` mode runs continuously, polling the current track and reflecting its **playback state** in your Slack status:
-
-- The `:music:` emoji stays as the Slack status emoji in every state (continuity).
-- **Playing**: status text is a random mythological creature emoji plus the currently playing track (song, artist, album), e.g. `♪♬  :phoenix_ash: Bohemian Rhapsody - Queen (A Night at the Opera)`.
-- **Paused**: status text becomes a myth-themed intermission line, e.g. `⏸️ :fox_face: the oracle is thinking… — Bohemian Rhapsody - Queen`. The phrase rotates through a pool (`PAUSED_PHRASES` in [`lib/slack.rb`](lib/slack.rb)) and only the title + artist are shown so longer track names fit under Slack's 100-grapheme limit.
-- **Nothing playing**: status text falls back to `🔇 sound of silence`.
-
-Press `Ctrl+C` to stop and automatically clear your status. If a previous run leaves a stale status behind, you can wipe it with `ruby slack_status.rb clear`.
-
-#### Adaptive refresh cadence
-
-The loop picks its sleep interval based on the last observed state, so paused → playing transitions feel snappy without busy-polling when nothing is happening:
-
-| State    | Sleep | Why |
-|----------|-------|-----|
-| Playing  | 120 s | Track titles change slowly; preserve Slack rate-limit budget. |
-| Paused   | 30 s  | Quick switch back to the playing line when you hit play. |
-| Silent   | 120 s | Nothing to refresh; long nap. |
-| Unknown (tick errored) | 120 s | Conservative fallback during transient failures. |
-
-Constants live at the top of [`lib/slack.rb`](lib/slack.rb) (`PLAYING_SLEEP`, `PAUSED_SLEEP`, `SILENT_SLEEP`) for easy tuning. Even the snappiest cadence (30 s) is well under Slack's Tier 3 budget for `users.profile.set` (~50 req/min).
-
-#### How the current track is detected
-
-`musical_myth` reads the track from macOS's system-wide "Now Playing" source via [`nowplaying-cli`](https://github.com/kirtan-shah/nowplaying-cli). That covers anything the OS treats as the active media source: the native `Music.app`, Spotify desktop, `music.apple.com` in any browser, QuickTime Player, Podcasts.app, and most browser tabs that integrate with the Media Session API (YouTube, SoundCloud, etc.).
-
-Playback state comes from the `playbackRate` property (mapped to the private `kMRMediaRemoteNowPlayingInfoPlaybackRate` field):
-
-- `playbackRate > 0` → **playing**
-- `playbackRate == 0` with a known title → **paused**
-- Missing `playbackRate` with a known title → assumed **playing** (back-compat for sources that omit the field)
-- No title → **silent**
-
-If `nowplaying-cli` is missing or returns no track, the loop silently falls back to AppleScript against the native `Music.app`. The fallback reads `player state` so it can distinguish `playing`, `paused`, and `stopped` the same way. If that also returns nothing, the status text falls back to `🔇 sound of silence`.
-
-Caveat: `nowplaying-cli` relies on the private `MediaRemote` framework. On modern macOS (14.4+) Apple has tightened access to this API. The maintained `nowplaying-cli` build works as of writing, but if Apple ever closes it further the primary path will return empty and the AppleScript fallback (native `Music.app` only) is what you'll be left with.
-
----
-
-## 💡 Examples
-
-```bash
-# Custom status with fire emoji
-ruby slack_status.rb custom "Deep in the code" ":fire:"
-
-# Custom status that expires in 1 hour (3600 seconds)
-ruby slack_status.rb custom "In a meeting" ":speech_balloon:" 3600
-
-# Heads-down / focus block for 2 hours
-ruby slack_status.rb custom "Heads down — focusing" ":no_entry:" 7200
-
-# Out of office for the rest of the workday (8 hours)
-ruby slack_status.rb custom "OOO — back tomorrow" ":palm_tree:" 28800
-
-# Doctor / personal appointment for 1 hour
-ruby slack_status.rb custom "Personal appointment" ":hospital:" 3600
-
-# Commute for 30 minutes
-ruby slack_status.rb custom "Commuting" ":bike:" 1800
-
-# Pairing session for 1 hour
-ruby slack_status.rb custom "Pairing" ":handshake:" 3600
-
-# Start music tracking (runs until stopped)
-ruby slack_status.rb musical_myth
-
-# Run music tracking in the background and stop it cleanly later
-ruby slack_status.rb musical_myth &
-kill %1   # TERM is trapped, so the status is cleared on exit
-
-# Debug music detection without touching Slack
-ruby lib/music.rb
-```
-
----
-
-## 📁 Project Structure
-
-```
-.
-├── slack_status.rb        # Main CLI script
-├── lib/
-│   ├── slack.rb          # Slack API integration
-│   └── music.rb          # Now-playing detection (nowplaying-cli + AppleScript fallback)
-└── README.md
-```
-
----
+- [Setup](docs/setup.md) — Slack App + manifest, OAuth helper, profiles, prerequisites.
+- [Security](docs/security.md) — token storage strategies, Dashlane integration, threat model, rotation.
+- [Usage](docs/usage.md) — full CLI reference: flags, modes, subcommands, expiration semantics.
+- [Musical Myth Mode](docs/musical-myth.md) — now-playing detection, adaptive cadence, fallbacks, caveats.
+- [Examples](docs/examples.md) — copy-pasteable invocations.
+- [Troubleshooting](docs/troubleshooting.md) — notes, gotchas, `doctor` workflow, common Slack errors.
+- [Architecture](docs/architecture.md) — project structure, token-resolver design, future work.
 
 ## Requirements
 
-- Ruby
-- macOS (for Apple Music integration)
-- Slack workspace with appropriate permissions
+- Ruby `~> 3.0` and Bundler.
+- macOS (for Apple Music integration and the `security`-backed Keychain backend).
+- A Slack workspace with permission to install a personal app. See [docs/setup.md](docs/setup.md).
 
----
-
-## ⚠️ Notes & Gotchas
-
-- **Status text is silently truncated to 100 graphemes** with an ellipsis (`…`). Long song titles or custom messages will be clipped at the last whitespace inside the limit.
-- **Track detection runs on every invocation, not just `musical_myth`.** The internal mode map is built eagerly, so `nowplaying-cli` (and the AppleScript fallback if needed) is shelled out even for `myth`, `lunch`, `break`, and `clear`. macOS is effectively required for any mode; on non-macOS systems the call fails and the script keeps going.
-- **Missing or invalid token → `not_authed`.** `SLACK_SECRET_TOKEN` is read once at load time with no validation. If it's unset or wrong, the request still fires and Slack responds with `❌ Failed to update status: not_authed`. Double-check `echo $SLACK_SECRET_TOKEN` before debugging further.
-- **Paused state depends on `playbackRate`.** A handful of media sources omit the field; for those, `musical_myth` will keep showing the playing line even while paused. Spot-check your main players (Spotify desktop, Music.app, browser tabs) the first time you run it.
-- **`clear` is your escape hatch.** If `musical_myth` (or any expiring status) leaves something stuck, run `ruby slack_status.rb clear` to wipe it.
-
----
-
-## 📜 License
+## License
 
 Intended to be MIT-licensed, but no `LICENSE` file is committed to the repo yet — treat the code as "all rights reserved" until one is added.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,105 @@
+# Architecture
+
+Project layout, the token-resolver design, and a few "we considered X" notes so future contributors don't relitigate the obvious questions.
+
+## Project structure
+
+```
+.
+├── slack_status.rb              # CLI entry point: OptionParser + subcommand dispatch
+├── Gemfile                      # Minimal: webrick (extracted from stdlib in Ruby 3.0)
+├── lib/
+│   ├── slack.rb                 # Slack API integration (users.profile.set, auth.test)
+│   ├── music.rb                 # Now-playing detection (nowplaying-cli + AppleScript fallback)
+│   ├── token_resolver.rb        # Profile-aware token resolver + Dashlane/Keychain/file/env backends
+│   ├── oauth_helper.rb          # WEBrick one-shot OAuth listener + oauth.v2.access exchange
+│   └── cli_prompt.rb            # Interactive UX helpers ([Y/n], secret input, emoji progress, scrub_secrets)
+├── docs/
+│   ├── setup.md                 # Slack App + manifest, prerequisites, setup walkthrough
+│   ├── security.md              # Token storage strategies, Dashlane, threat model, rotation
+│   ├── usage.md                 # Full CLI reference: flags, modes, subcommands
+│   ├── musical-myth.md          # Now-playing detection deep-dive
+│   ├── examples.md              # Copy-pasteable invocations
+│   ├── troubleshooting.md       # Notes, gotchas, Slack error decoder
+│   ├── architecture.md          # This file
+│   └── slack-app-manifest.yml   # Slack App manifest (paste at app creation time)
+└── README.md
+```
+
+## Token resolver
+
+`TokenResolver.new(profile:, cli_token:, config_path:).resolve` walks a fixed precedence chain and returns `{ token:, source:, profile: }`. First non-empty wins; no silent fallbacks.
+
+```
+1. --token CLI flag           (cli:--token)
+2. SLACK_STATUS_TOKEN_<PROFILE> env var
+3. Config-driven backend      (profile entry merged with global; profile wins on collision)
+     dashlane  → `dcli read dl://<title>`
+     keychain  → `security find-generic-password -s slack-status-cli -a <profile> -w`
+     file      → ~/.config/slack-status-cli/tokens/<profile>  (refuses to read if mode allows group/other)
+     env       → ENV[backend_options.env.var || SLACK_STATUS_TOKEN_<PROFILE>]
+4. SLACK_SECRET_TOKEN         (legacy fallback — see scope below)
+```
+
+The legacy `SLACK_SECRET_TOKEN` is **only** consulted when **all** of the following are true:
+
+- the active profile is `default`,
+- no `profiles.default` block exists in the config,
+- and no backend resolved a token in step 3.
+
+For any non-default profile, or any profile that has an explicit `profiles.<name>` block, the legacy env var is intentionally ignored. This prevents a token belonging to one workspace (e.g. your work Slack export) from silently being used when you ran `--profile personal`. When that situation is detected, `NotFoundError` is raised with the exact remediation steps.
+
+### Global profile inheritance
+
+Modeled after `git config --global`. The `global:` section in `~/.config/slack-status-cli/config.yml` defines defaults inherited by every profile; profile-level keys win on collision.
+
+```yaml
+global:
+  oauth:
+    client_id: "1234567890.0987654321"
+    client_secret_ref: "dl://slack-status-cli/oauth-client-secret"
+  storage_backend: dashlane
+
+profiles:
+  work:
+    token_ref: "dl://slack-status-cli/work-token"
+  personal:
+    token_ref: "dl://slack-status-cli/personal-token"
+    storage_backend: keychain     # overrides global
+```
+
+`TokenResolver#merged_settings` deep-merges the two before any backend lookup, so a backend never sees the unmerged form. The OAuth `client_id` and `client_secret_ref` belong in `global` because they're properties of the Slack App (one App per repo), not of an individual workspace token.
+
+## Why no `slack` CLI for token generation
+
+Slack's official `slack` CLI ([api.slack.com/automation/cli](https://api.slack.com/automation/cli)) targets the next-gen automation platform — Deno-based Functions and Workflows. The tokens it can mint are app-level and bot-level (`xoxa-`, `xoxb-`), not the `xoxp-` **user token** with `users.profile:write` scope that this CLI needs.
+
+User tokens are gated behind the OAuth install flow. The realistic automated path is what `setup` does:
+
+1. User creates a Slack App once (one-click via the shipped manifest).
+2. `setup` boots a one-shot WEBrick listener on `127.0.0.1:53682`.
+3. Browser opens `https://slack.com/oauth/v2/authorize?...&user_scope=users.profile:write&state=...`.
+4. Slack redirects to `http://localhost:53682/callback?code=...&state=...`.
+5. `setup` POSTs to `oauth.v2.access` with HTTP Basic (client_id:client_secret).
+6. The returned `authed_user.access_token` is the `xoxp-` token. It's persisted via the selected backend.
+
+Community tools that "auto-extract" `xoxc`/`xoxd` from the Slack web client exist but use undocumented tokens incompatible with `users.profile.set`. They break frequently. We don't support them.
+
+## Why WEBrick
+
+WEBrick is the simplest HTTP server that ships with Ruby and was removed from stdlib in Ruby 3.0. The OAuth helper needs exactly one short-lived `/callback` handler — no need for Puma/Sinatra/etc. Pinning the `webrick` gem (`~> 1.8`) in the `Gemfile` keeps the dep surface tiny.
+
+## Conventions for `docs/`
+
+- Plain GitHub-rendered markdown — no MkDocs/Docusaurus build step. The repo is small enough that a static site generator would be overkill.
+- Cross-links are relative (`[setup.md](setup.md)`, `[../lib/slack.rb](../lib/slack.rb)`) so the repo browses correctly on GitHub and on a local clone.
+- Every `docs/*.md` opens with an H1 matching the README link text and a one-sentence purpose blurb, so search results are self-describing.
+
+## Future work
+
+- **Adopt RSpec.** The repo has no `spec/` yet; manual test plans in PR descriptions are the substitute. A first follow-up should scaffold RSpec and add coverage for `TokenResolver` (precedence chain, backend dispatch, `FileBackend` perm-guard, merged settings).
+- **Real ticket tracker.** The workspace rule mandates `em/PI-XXX_*` branch names, but `PI-XXX` is currently synthetic. Wiring Linear / GitHub Issues would let the PR template link real tickets.
+- **Windows / Linux Keychain equivalents.** `KeychainBackend` currently shells out to macOS `security`. `secret-tool` (libsecret) on Linux and `wincred` on Windows would be drop-in replacements once the tool grows past macOS.
+- **Scheduled rotation.** Today `setup --rotate` is on-demand. A cron-friendly `slack_status.rb rotate` that revokes the old token via `auth.revoke` and stores the new one would round out the lifecycle.
+- **Multi-org Dashlane.** `dcli` supports team vaults via `DASHLANE_TEAM_DEVICE_CREDENTIALS`; the current backend is personal-vault only.
+- **Optional MkDocs / Docusaurus build for `docs/`** if the docs keep growing. Right now plain markdown is fine; revisit if we cross ~15 docs files or add diagrams that need a custom renderer.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,61 @@
+# Examples
+
+Copy-pasteable invocations. See [Usage](usage.md) for the full flag reference.
+
+```bash
+# Default — random mythological beast emoji on the active profile
+ruby slack_status.rb
+
+# Pick a profile explicitly (or set $SLACK_STATUS_PROFILE)
+ruby slack_status.rb --profile work myth
+
+# Custom status with fire emoji
+ruby slack_status.rb custom "Deep in the code" ":fire:"
+
+# Custom status that expires in 1 hour (3600 seconds)
+ruby slack_status.rb custom "In a meeting" ":speech_balloon:" 3600
+
+# Heads-down / focus block for 2 hours
+ruby slack_status.rb custom "Heads down — focusing" ":no_entry:" 7200
+
+# Out of office for the rest of the workday (8 hours)
+ruby slack_status.rb custom "OOO — back tomorrow" ":palm_tree:" 28800
+
+# Doctor / personal appointment for 1 hour
+ruby slack_status.rb custom "Personal appointment" ":hospital:" 3600
+
+# Commute for 30 minutes
+ruby slack_status.rb custom "Commuting" ":bike:" 1800
+
+# Pairing session for 1 hour
+ruby slack_status.rb custom "Pairing" ":handshake:" 3600
+
+# Start music tracking (runs until stopped)
+ruby slack_status.rb musical_myth
+
+# Run music tracking in the background and stop it cleanly later
+ruby slack_status.rb musical_myth &
+kill %1   # TERM is trapped, so the status is cleared on exit
+
+# Use a one-off token without touching the resolver / config
+ruby slack_status.rb --token xoxp-... clear
+
+# Pull the token from Dashlane and pass it via env (one-shot)
+dcli exec -- ruby slack_status.rb --token "$DASHLANE_SLACK_TOKEN" myth
+
+# Validate the active profile's token
+ruby slack_status.rb doctor --profile personal
+
+# Configure global defaults once, then add multiple profiles
+ruby slack_status.rb setup --global --client-id 1234.5678 --backend dashlane
+ruby slack_status.rb setup --profile personal
+ruby slack_status.rb setup --profile work
+
+# Inspect / edit the config
+ruby slack_status.rb config get global.storage_backend
+ruby slack_status.rb config set profiles.work.storage_backend keychain
+ruby slack_status.rb profiles list
+
+# Debug music detection without touching Slack
+ruby lib/music.rb
+```

--- a/docs/musical-myth.md
+++ b/docs/musical-myth.md
@@ -1,0 +1,49 @@
+# Musical Myth Mode
+
+Continuous now-playing → Slack status sync with mythological flair.
+
+```bash
+ruby slack_status.rb musical_myth
+```
+
+The loop runs continuously, polling the currently playing track and reflecting its **playback state** in your Slack status:
+
+- The `:music:` emoji stays as the Slack status emoji in every state (continuity).
+- **Playing**: status text is a random mythological creature emoji plus the currently playing track (song, artist, album), e.g. `♪♬  :phoenix_ash: Bohemian Rhapsody - Queen (A Night at the Opera)`.
+- **Paused**: status text becomes a myth-themed intermission line, e.g. `⏸️ :fox_face: the oracle is thinking… — Bohemian Rhapsody - Queen`. The phrase rotates through a pool (`PAUSED_PHRASES` in [`../lib/slack.rb`](../lib/slack.rb)) and only the title + artist are shown so longer track names fit under Slack's 100-grapheme limit.
+- **Nothing playing**: status text falls back to `🔇 sound of silence`.
+
+Press `Ctrl+C` to stop and automatically clear your status. If a previous run leaves a stale status behind, you can wipe it with `ruby slack_status.rb clear`.
+
+## Adaptive refresh cadence
+
+The loop picks its sleep interval based on the last observed state, so paused → playing transitions feel snappy without busy-polling when nothing is happening:
+
+| State    | Sleep | Why |
+|----------|-------|-----|
+| Playing  | 120 s | Track titles change slowly; preserve Slack rate-limit budget. |
+| Paused   | 30 s  | Quick switch back to the playing line when you hit play. |
+| Silent   | 120 s | Nothing to refresh; long nap. |
+| Unknown (tick errored) | 120 s | Conservative fallback during transient failures. |
+
+Constants live at the top of [`../lib/slack.rb`](../lib/slack.rb) (`PLAYING_SLEEP`, `PAUSED_SLEEP`, `SILENT_SLEEP`) for easy tuning. Even the snappiest cadence (30 s) is well under Slack's Tier 3 budget for `users.profile.set` (~50 req/min).
+
+## How the current track is detected
+
+`musical_myth` reads the track from macOS's system-wide "Now Playing" source via [`nowplaying-cli`](https://github.com/kirtan-shah/nowplaying-cli). That covers anything the OS treats as the active media source: the native `Music.app`, Spotify desktop, `music.apple.com` in any browser, QuickTime Player, Podcasts.app, and most browser tabs that integrate with the Media Session API (YouTube, SoundCloud, etc.).
+
+Playback state comes from the `playbackRate` property (mapped to the private `kMRMediaRemoteNowPlayingInfoPlaybackRate` field):
+
+- `playbackRate > 0` → **playing**
+- `playbackRate == 0` with a known title → **paused**
+- Missing `playbackRate` with a known title → assumed **playing** (back-compat for sources that omit the field)
+- No title → **silent**
+
+If `nowplaying-cli` is missing or returns no track, the loop silently falls back to AppleScript against the native `Music.app`. The fallback reads `player state` so it can distinguish `playing`, `paused`, and `stopped` the same way. If that also returns nothing, the status text falls back to `🔇 sound of silence`.
+
+## Caveats
+
+- `nowplaying-cli` relies on the private `MediaRemote` framework. On modern macOS (14.4+) Apple has tightened access to this API. The maintained `nowplaying-cli` build works as of writing, but if Apple ever closes it further the primary path will return empty and the AppleScript fallback (native `Music.app` only) is what you'll be left with.
+- **Track detection runs on every invocation, not just `musical_myth`.** The internal mode map is built eagerly, so `nowplaying-cli` (and the AppleScript fallback if needed) is shelled out even for `myth`, `lunch`, `break`, and `clear`. macOS is effectively required for any mode; on non-macOS systems the call fails and the script keeps going.
+- **Paused state depends on `playbackRate`.** A handful of media sources omit the field; for those, `musical_myth` will keep showing the playing line even while paused. Spot-check your main players (Spotify desktop, Music.app, browser tabs) the first time you run it.
+- See [Troubleshooting](troubleshooting.md) for more gotchas.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,76 @@
+# Security
+
+How `slack-status-cli` keeps your Slack user token safe at rest, in transit, and in logs.
+
+## Recommended storage order
+
+| Backend | Strengths | Weaknesses |
+|---|---|---|
+| `dashlane` (default) | Encrypted vault; sync across devices; same store as the rest of your credentials | One-time `dcli sync` unlock; manual write step (Dashlane personal has no unattended write API) |
+| `keychain` | macOS-native; encrypted; programmatic read + write via `security`; survives across shells | macOS only |
+| `file` | Simple; works in any tool; explicit | Plaintext on disk; relies on filesystem perms (we enforce `0600`) |
+| `env` | Easy to script; convenient for CI | Leaks into process listings (`ps`), shell history, child processes |
+
+The resolver walks `--token > SLACK_STATUS_TOKEN_<PROFILE> > config-driven backend (profile -> global) > SLACK_SECRET_TOKEN (legacy, default profile only)`. Diagram and full description in [docs/architecture.md](architecture.md#token-resolver). The legacy env var is **never** used for an explicitly named or explicitly configured profile, to prevent cross-workspace token leakage.
+
+## Dashlane integration
+
+`slack-status-cli` shells out to `dcli read dl://<title>` to fetch the token. Setup:
+
+```bash
+brew install dashlane/tap/dashlane-cli       # macOS / Linux; Windows + manual installs: cli.dashlane.com/install
+dcli sync                                    # one-time interactive unlock
+ruby slack_status.rb setup --profile personal --backend dashlane
+```
+
+The `setup` command can't write to Dashlane personal directly (no unattended write API), so it prints a one-time block with the token + the exact secure-note title to create. Once the note is saved:
+
+```bash
+dcli read dl://slack-status-cli/personal-token   # should print the token to stdout
+ruby slack_status.rb doctor --profile personal   # validates against auth.test
+```
+
+For one-shot invocations from scripts you can bypass the resolver entirely:
+
+```bash
+dcli exec -- ruby slack_status.rb --token "$DASHLANE_TOKEN" myth
+```
+
+If `dcli` isn't installed or the vault is locked, the resolver falls through to the next backend the profile is configured for (no silent fallback — the chain is explicit in [docs/architecture.md](architecture.md#token-resolver)).
+
+## Security strategies (what the code enforces)
+
+- **Default to a secret manager, not env vars.** The `setup` flow recommends Dashlane > Keychain > file > env in that order.
+- **Scope minimization.** The shipped manifest ([`docs/slack-app-manifest.yml`](slack-app-manifest.yml)) requests only `users.profile:write` as a user scope. No bot scopes, no `chat:write`.
+- **Token-at-rest only.** `~/.config/slack-status-cli/config.yml` never stores the token — it only stores the *reference* (which backend + key/title) and the OAuth `client_id`. `client_secret` is read via `client_secret_ref` (a `dl://…`, `env:VAR`, or `file:/path` URI) or prompted with echo off.
+- **`FileBackend` perm-guard.** Writing a token via `file` backend chmods the file `0600`. Reading refuses (and falls through) if `(stat.mode & 0o077) != 0`, so a misconfigured permission can't silently leak the secret.
+- **Validate at setup + on demand.** `doctor` calls `auth.test` to fail fast with a useful error code (`not_authed`, `missing_scope`, etc.) instead of letting `users.profile.set` return cryptic errors later.
+- **No token in logs.** `--verbose` prints the *source* of the resolved token (`resolved from dashlane:dl://slack-status-cli/work`) but never the value. Any caught exception passes through `CliPrompt.scrub_secrets` which replaces `xox[a-z]-…` patterns with `xox?-…XXXX`.
+- **State + loopback guard on OAuth.** The helper generates a 16-byte hex `state`, includes it in the authorize URL, and rejects callbacks where it doesn't match. The WEBrick listener binds to `127.0.0.1` (not `0.0.0.0`) so other hosts on the LAN can't race the callback.
+- **Per-profile isolation.** Each profile has its own backend entry; compromising one workspace's token doesn't leak others. Profiles can mix backends (work in Dashlane, personal in Keychain).
+- **One-shot listener.** WEBrick shuts down after the first successful callback (or a 2-minute timeout). Reduces the window for a malicious local process to hit `/callback`.
+
+## Threat model checklist
+
+| Threat | Mitigation |
+|---|---|
+| Shoulder-surf at install time | Client Secret prompt disables terminal echo; token is printed once with a redacted preview |
+| Shell history (`ctrl-r`) leaks | Don't pass `--token` or `--client-secret` on the command line; use prompts or `dcli exec` |
+| `ps`/`top` shows args | Same — secret-bearing CLI flags are visible in process listings |
+| Lost laptop | Dashlane / Keychain are encrypted at rest; file backend relies on FileVault |
+| Compromised single profile | Per-profile tokens limit blast radius; `auth.revoke` + `setup --rotate` to rebuild |
+| Malicious local process | OAuth listener binds 127.0.0.1 only; `state` validates the callback origin; one-shot listener |
+
+## Rotation
+
+```bash
+ruby slack_status.rb setup --profile personal --rotate
+```
+
+That re-runs OAuth and overwrites the stored token. To also invalidate the old token server-side, hit `auth.revoke`:
+
+```bash
+curl -s -H "Authorization: Bearer xoxp-OLD-TOKEN" https://slack.com/api/auth.revoke | jq .
+```
+
+If you suspect a leak, rotate first (so the new token is available), then revoke the old one.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,174 @@
+# Setup
+
+End-to-end walkthrough: install the prerequisites, create the Slack App from the shipped manifest, run the OAuth helper, and verify with `doctor`.
+
+## Prerequisites
+
+| Tool | Required? | Install one-liner |
+|---|---|---|
+| **Ruby `~> 3.0`** | Required | `brew install ruby@3` (or `mise install ruby@3` / `rbenv install 3.x`) |
+| **Bundler** | Required | `gem install bundler` (then `bundle install` in this repo to pull `webrick`) |
+| **`nowplaying-cli`** | Required for `musical_myth` | `brew install nowplaying-cli` |
+| **Dashlane CLI (`dcli`)** | Recommended (primary backend) | `brew install dashlane/tap/dashlane-cli`, then one-time `dcli sync`; verify with `dcli --version`. Other platforms / install methods: [`cli.dashlane.com/install`](https://cli.dashlane.com/install). |
+| **Slack CLI (`slack`)** | **Optional** | `brew install slackapi/slack-cli/slack-cli`. **Not required** for `slack-status-cli` — it's only useful for managing your Slack App from the terminal. See [api.slack.com/automation/cli](https://api.slack.com/automation/cli) and the [architecture note on why this CLI can't generate user tokens](architecture.md#why-no-slack-cli-for-token-generation). |
+| **macOS Keychain (`security`)** | Preinstalled on macOS | No action needed. Listed for completeness as a backup backend. |
+
+## 1. Create the Slack App from the manifest
+
+1. Open <https://api.slack.com/apps?new_app=1>.
+2. Pick **"From a manifest"** and select your workspace.
+3. Paste the contents of [`docs/slack-app-manifest.yml`](slack-app-manifest.yml) and confirm.
+4. Open **Basic Information** in the new app. Copy the **Client ID** and **Client Secret**.
+
+The manifest pre-fills:
+
+- `user_scope: users.profile:write` — required to edit your own status.
+- `user_scope: emoji:read` — required by [`migrate-emojis`](usage.md#migrate-emojis); not used by any status mode. Listing/downloading only — never writes.
+- `redirect_url: http://localhost:53682/callback` — matches what the OAuth helper listens on.
+
+> **Upgrading existing installs.** If your app was created before `emoji:read` was added to the manifest, the existing token won't have it. Re-run `setup --profile <name> --rotate` to re-OAuth and pick up the new scope (the manifest itself updates automatically when you "Update from manifest" in the Slack App settings UI).
+
+> **Multi-workspace setups: one app per workspace.** Slack apps default to "internal" (single-workspace) install. Enabling **Distribution** to install one app across multiple workspaces requires an **HTTPS** redirect URL, which loopback (`http://localhost`) doesn't satisfy. The simplest workaround is to create **one Slack App per workspace** from the same manifest. Each app stays internal and keeps `http://localhost:53682/callback`. `slack-status-cli` handles this by storing `client_id` per profile (see [Multi-workspace setup](#multi-workspace-setup) below).
+
+## 2. (One time) Set global defaults
+
+Stash the OAuth client ID + your preferred storage backend so every profile inherits them:
+
+```bash
+ruby slack_status.rb setup --global --client-id <YOUR_CLIENT_ID> --backend dashlane
+```
+
+`--backend` is one of `dashlane` (recommended), `keychain`, `file`, or `env`. See [Security](security.md) for trade-offs.
+
+This writes `~/.config/slack-status-cli/config.yml` with permissions `0600`. The client secret is **not** stored in the file — provide it interactively per setup, or point `global.oauth.client_secret_ref` at a Dashlane URI / env var.
+
+If you'll have **more than one Slack App** (one per workspace — recommended for multi-workspace setups), it's fine to skip Step 2 entirely. Profile-level `client_id`s persist automatically in Step 3.
+
+## 3. Run setup for each profile
+
+```bash
+ruby slack_status.rb setup --profile personal
+```
+
+The script walks you through 4 steps with emoji progress markers. The first time you run it (no cached `client_id`), Step 1 prints a `✋` block telling you exactly how to create the Slack App from the manifest and where to copy the credentials before it prompts for them. Subsequent profile setups just ask whether to reuse the cached values.
+
+### First-time output (no global config yet)
+
+```
+🔧 Step 1/4: Slack App configuration
+
+✋ Manual step required
+   Where to find your Client ID + Client Secret:
+     1) Open https://api.slack.com/apps?new_app=1
+     2) Pick "From a manifest", then pick your workspace.
+     3) Paste the contents of docs/slack-app-manifest.yml and confirm.
+     4) On the new app's "Basic Information" page, scroll to "App Credentials":
+        - Client ID looks like 1234567890123.0987654321098
+        - Click "Show" next to Client Secret to reveal it.
+     5) The manifest pre-fills the OAuth redirect URL; double-check it under
+        "OAuth & Permissions" → "Redirect URLs": http://localhost:53682/callback
+
+   Press Enter once you're done… _
+Enter Client ID (from Basic Information): 1234567890123.0987654321098
+Enter Client Secret (from Basic Information; input hidden): ********
+
+🔧 Step 2/4: Choose a token storage backend
+   Use the default backend `dashlane`? [Y/n]
+✅ Backend: dashlane
+
+🔧 Step 3/4: OAuth install
+🌐 Opening https://slack.com/oauth/v2/authorize?… in your browser.
+   Listening on http://localhost:53682/callback (2 min timeout)…
+✅ Received authorization code; exchanging for user token…
+✅ Got xoxp-…XXXX (scope=users.profile:write, team=Acme)
+
+🔧 Step 4/4: Persist the token
+🔐 Wrote token to dashlane:dl://slack-status-cli/personal-token.
+✅ Setup complete. Verify with: ruby slack_status.rb doctor --profile personal
+```
+
+### Returning user (cached global config)
+
+```
+🔧 Step 1/4: Slack App configuration
+   Found global client_id ending in …4321. Reuse it? [Y/n]
+✅ Using global client_id ending in …4321.
+Enter Client Secret (from Basic Information; input hidden): ********
+... (steps 2-4 as above)
+```
+
+Conventions baked into the prompts:
+
+- `[Y/n]` / `[y/N]` defaults follow the bash idiom — Enter accepts the capitalized option.
+- The Client Secret prompt disables terminal echo (`io.noecho`); the script never echoes it back in full. Confirmation lines truncate to the last 4 chars (`…1234`).
+- `✋` blocks pause for an Enter press whenever the script needs you to act outside the terminal.
+- `--non-interactive` skips every prompt and fails fast if a required value is missing — useful for scripted reruns.
+- `--rotate` re-runs OAuth and overwrites the existing token for the profile.
+
+## 4. Verify
+
+```bash
+ruby slack_status.rb doctor --profile personal
+```
+
+Expected output (token redacted):
+
+```
+   source : dashlane:dl://slack-status-cli/personal-token
+   profile: personal
+   token  : xoxp-…XXXX
+✅ auth.test ok — workspace=Acme user=eric url=https://acme.slack.com/
+```
+
+Failure modes get specific hints (re-run setup, missing scope, deactivated account, etc.). See [Troubleshooting](troubleshooting.md).
+
+## Profile management
+
+- Active profile: `--profile <name>` flag, `SLACK_STATUS_PROFILE` env var, or `"default"` when neither is set.
+- Profile-scoped env var: `SLACK_STATUS_TOKEN_<PROFILE>` (e.g. `SLACK_STATUS_TOKEN_WORK`) overrides config-based resolution. Useful for CI.
+- List profiles: `ruby slack_status.rb profiles list`.
+- Inspect / change config: `ruby slack_status.rb config get global.storage_backend`, `config set profiles.work.storage_backend keychain`.
+- The config file is at `~/.config/slack-status-cli/config.yml` (override with `--config PATH`).
+
+## Multi-workspace setup
+
+If you belong to more than one Slack workspace and want to flip your status between them, the recommended path is **one Slack App per workspace**. Each app stays internal (no Distribution toggle, no HTTPS redirect requirement), and each profile pins the right app's credentials.
+
+1. **Create the first app** by following Step 1 above against your first workspace. Copy that Client ID/Secret.
+2. **Create the second app** by repeating Step 1 against your second workspace. Same manifest, different workspace, different Client ID/Secret.
+3. **Run setup once per profile**, passing the matching Client ID:
+
+   ```bash
+   ruby slack_status.rb setup --profile negotiatus --client-id <AAA>
+   ruby slack_status.rb setup --profile personal   --client-id <BBB>
+   ```
+
+   At Step 4 (Persist the token), `slack-status-cli` writes the per-profile `client_id` to `profiles.<name>.oauth.client_id` **only when it differs from the global default**, so the config stays tidy:
+
+   ```yaml
+   global:
+     oauth:
+       client_id: <AAA>          # also used by `negotiatus`, no per-profile entry needed
+     storage_backend: dashlane
+
+   profiles:
+     negotiatus:
+       storage_backend: dashlane # inherits client_id from global
+     personal:
+       storage_backend: dashlane
+       oauth:
+         client_id: <BBB>        # overrides global because it diverges
+   ```
+
+4. **Switch workspaces** by switching profiles:
+
+   ```bash
+   ruby slack_status.rb --profile negotiatus lunch
+   ruby slack_status.rb --profile personal   musical_myth
+   ruby slack_status.rb doctor --profile personal
+   # ✅ auth.test ok — workspace=efmcuiti user=eric url=https://efmcuiti.slack.com/
+   ```
+
+`doctor` calls `auth.test` against whichever workspace the resolved token is bound to, so it's a one-liner sanity check after every setup or rotate.
+
+See [docs/usage.md](usage.md) for the full flag/command reference, and [docs/security.md](security.md) for token storage trade-offs.

--- a/docs/slack-app-manifest.yml
+++ b/docs/slack-app-manifest.yml
@@ -1,0 +1,40 @@
+# Slack App manifest for slack-status-cli.
+#
+# Usage:
+#   1. Open https://api.slack.com/apps?new_app=1
+#   2. Pick "From a manifest"
+#   3. Pick your workspace
+#   4. Paste the contents of this file
+#   5. Confirm; Slack will create the app with exactly the right scope + redirect.
+#
+# Notes:
+#   - We request only two user scopes:
+#       - `users.profile:write` so the app can edit YOUR profile status.
+#       - `emoji:read` so `migrate-emojis` can list custom emojis on the
+#         source workspace and download them. (Read-only; never writes.)
+#     No bot scopes, no chat:write, no other reads.
+#   - No `features.bot_user` block: this app does not have a bot identity, so
+#     declaring one without bot scopes would fail manifest validation with
+#     "Bot user requires bot scope".
+#   - The redirect URL points at localhost; our OAuth helper boots a one-shot
+#     listener on 127.0.0.1:53682 to capture the install callback.
+#   - Change `name` / `description` / `background_color` to taste; they're
+#     purely cosmetic in the Slack app directory.
+
+display_information:
+  name: slack-status-cli
+  description: Personal CLI for setting my Slack status with mythological flair.
+  background_color: "#1f1235"
+
+oauth_config:
+  redirect_urls:
+    - http://localhost:53682/callback
+  scopes:
+    user:
+      - users.profile:write
+      - emoji:read
+
+settings:
+  org_deploy_enabled: false
+  socket_mode_enabled: false
+  token_rotation_enabled: false

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,43 @@
+# Troubleshooting
+
+Notes, gotchas, and a decoder for the Slack-side error codes you may see.
+
+## First step: run `doctor`
+
+```bash
+ruby slack_status.rb doctor --profile <name>
+```
+
+`doctor` resolves the token, prints the source it came from (without ever logging the value), and calls Slack's `auth.test`. Every failure mode prints a specific recovery hint. If `doctor` is happy and a status command still fails, the bug is almost certainly elsewhere (track detection, status formatting, etc.).
+
+## Slack error decoder
+
+| `error` field | What it means | What to do |
+|---|---|---|
+| `not_authed` | No token sent (or empty bearer). | The resolver returned an empty string. Check `--verbose` to see which source was used; `setup --profile <name> --rotate` to refresh. |
+| `invalid_auth` | Token sent but Slack doesn't recognize it. | Token is wrong / corrupted. `setup --profile <name> --rotate`. |
+| `token_revoked` | Token was valid; you revoked it (intentionally or via `auth.revoke`). | `setup --profile <name> --rotate`. |
+| `missing_scope` | Token lacks `users.profile:write`. | Re-create the Slack App from [`slack-app-manifest.yml`](slack-app-manifest.yml), or edit the existing app's OAuth & Permissions page to add the user scope, then `setup --profile <name> --rotate`. |
+| `account_inactive` | The Slack user owning this token is deactivated. | Use a different account. |
+| `rate_limited` | Slack is throttling. | Wait and retry. `musical_myth`'s adaptive cadence is tuned for the Tier 3 budget; if you hit this regularly something else is consuming the budget. |
+
+## Gotchas
+
+- **Status text is silently truncated to 100 graphemes** with an ellipsis (`…`). Long song titles or custom messages will be clipped at the last whitespace inside the limit.
+- **Track detection runs on every invocation, not just `musical_myth`.** The internal mode map is built eagerly, so `nowplaying-cli` (and the AppleScript fallback if needed) is shelled out even for `myth`, `lunch`, `break`, and `clear`. macOS is effectively required for any mode; on non-macOS systems the call fails and the script keeps going.
+- **Paused state depends on `playbackRate`.** A handful of media sources omit the field; for those, `musical_myth` will keep showing the playing line even while paused. Spot-check your main players (Spotify desktop, Music.app, browser tabs) the first time you run it.
+- **`clear` is your escape hatch.** If `musical_myth` (or any expiring status) leaves something stuck, run `ruby slack_status.rb clear` to wipe it.
+- **`FileBackend` refuses world-readable files.** If you `chmod 644` your token file the resolver warns and skips it (`refusing to read … permissions 644 are too open (chmod 600)`). Fix with `chmod 600`.
+- **Dashlane writes are manual.** The `setup` flow can't programmatically add a secure note to Dashlane personal vaults. It prints the title + token once with instructions; copy them into Dashlane, then `doctor` confirms the round-trip.
+- **`webrick` is no longer in stdlib.** As of Ruby 3.0 you need `bundle install` (the `Gemfile` pins `webrick`) for `setup` to work.
+
+## Logs and redaction
+
+- `--verbose` prints the **source** of the resolved token to stderr (e.g. `[slack-status-cli] token resolved from dashlane:dl://slack-status-cli/work (profile=work)`). It never prints the value.
+- Any caught exception is passed through `CliPrompt.scrub_secrets`, which substitutes `xox[a-z]-…` patterns with `xox?-…XXXX`. If you spot a real token in any log line, that's a bug — please file an issue with the trace.
+
+## OAuth helper getting stuck
+
+- The listener binds `127.0.0.1:53682`. If another process is using that port, `setup` will fail with `Address already in use`. Kill the squatter or change the port (currently hardcoded in [`../lib/oauth_helper.rb`](../lib/oauth_helper.rb)).
+- The listener has a 2-minute timeout. If your browser is slow or you closed the tab, re-run `setup --rotate`.
+- State mismatch (CSRF guard) means Slack returned a different `state` than we sent. Re-run; if it persists, your browser may be replaying an old authorize URL.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,165 @@
+# Usage
+
+Full CLI reference for `slack_status.rb`. For installation + token setup see [Setup](setup.md); for end-to-end recipes see [Examples](examples.md).
+
+## Invocation shape
+
+```
+ruby slack_status.rb [global flags] <command> [command args]
+```
+
+`<command>` is either:
+
+- A **mode** (`myth`, `lunch`, `break`, `clear`, `musical_myth`, or any other value treated as `custom`), or
+- A **subcommand** (`setup`, `doctor`, `config`, `profiles`, `migrate-emojis`).
+
+Global flags must come **before** the command. Anything after the command is passed to that command.
+
+## Global flags
+
+| Flag | Description |
+|---|---|
+| `--profile NAME` | Profile name. Default: `$SLACK_STATUS_PROFILE` or `default`. |
+| `--token TOKEN` | Use this token directly (highest precedence; bypasses the resolver). |
+| `--config PATH` | Path to `config.yml`. Default: `~/.config/slack-status-cli/config.yml`. |
+| `--verbose` | Print resolver's chosen token source to stderr. Source only — never the token. |
+| `--non-interactive` | Fail fast instead of prompting (`setup` and `doctor` only). |
+| `--rotate` | (setup) Overwrite an existing token instead of skipping. |
+| `--global` | (setup) Configure global defaults; skip OAuth + profile-token persistence. |
+| `--backend NAME` | (setup) Storage backend: `dashlane`, `keychain`, `file`, `env`. |
+| `--client-id ID` | (setup) Slack App client_id (overrides `global.oauth.client_id`). |
+| `--client-secret SECRET` | (setup) Slack App client_secret. **Prefer the interactive prompt** — CLI args leak into `ps` and shell history. |
+| `--from PROFILE` | (migrate-emojis) Source profile to download emojis from. |
+| `--to PROFILE` | (migrate-emojis) Destination profile; used to derive the workspace's emoji admin URL via `auth.test`. |
+| `--out DIR` | (migrate-emojis) Output directory. Default: `./emoji-export-<from>-<YYYYMMDD-HHMMSS>`. |
+| `--filter REGEX` | (migrate-emojis) Case-insensitive regex; only emoji whose name matches are downloaded. |
+| `--no-open` | (migrate-emojis) Don't automatically open the destination admin URL in a browser. |
+| `-h`, `--help` | Show the OptionParser banner and exit. |
+
+## Status modes
+
+All status modes resolve the token via the [precedence chain](architecture.md#token-resolver) and POST to `users.profile.set`.
+
+```bash
+ruby slack_status.rb [--profile NAME] [--token TOKEN] <mode> [text] [emoji] [expiration_seconds]
+```
+
+| Mode | Behavior |
+|---|---|
+| `myth` (default when no mode given) | Random mythological-beast emoji, no text. |
+| `lunch` | Sets `:meat_on_bone:` + `"<myth_emoji> - Lunch time!"`, expires in 1 hour. |
+| `break` | Sets `:coffee:` + `"<myth_emoji> Taking a break"`, expires in 30 min. |
+| `clear` | Wipes status (`status_text=""`, `status_emoji=""`, `status_expiration=0`). |
+| `musical_myth` | Runs forever; updates status with the currently playing track. See [Musical Myth Mode](musical-myth.md). |
+| anything else (e.g. `custom`, `focus`, `""`) | Custom status. `text`, `emoji`, `expiration_seconds` from positional args. |
+
+### Custom mode args
+
+| Position | Name | Type | Notes |
+|---|---|---|---|
+| 1 | `text` | string | Status text. Silently truncated to 100 graphemes with `…`. |
+| 2 | `emoji` | string | Slack-style code like `:fire:`. |
+| 3 | `expiration_seconds` | integer string | Added to `Time.now.to_i` to set `status_expiration`. Non-integer values are ignored (no expiration). |
+
+The integer-only validation lives in `evaluate_expiration` / `integer_string?` in [`../lib/slack.rb`](../lib/slack.rb). Pass `0` or omit to set a sticky status.
+
+## Subcommands
+
+### `setup`
+
+Configures a profile (or `--global` defaults). See [Setup](setup.md) for the canonical walkthrough.
+
+```bash
+ruby slack_status.rb setup [--global] [--profile NAME] [--rotate] [--non-interactive]
+                           [--backend NAME] [--client-id ID] [--client-secret SECRET]
+```
+
+### `doctor`
+
+Resolves the token for the active profile, calls `auth.test`, and prints the workspace/user + resolved source. Exits non-zero on failure.
+
+```bash
+ruby slack_status.rb doctor [--profile NAME] [--token TOKEN] [--verbose]
+```
+
+Output (token redacted):
+
+```
+   source : dashlane:dl://slack-status-cli/personal-token
+   profile: personal
+   token  : xoxp-…XXXX
+✅ auth.test ok — workspace=Acme user=eric url=https://acme.slack.com/
+```
+
+### `config`
+
+Read/write the YAML config file at `~/.config/slack-status-cli/config.yml` (or `--config PATH`).
+
+```bash
+ruby slack_status.rb config get <dotted.key>
+ruby slack_status.rb config set <dotted.key> <value>
+ruby slack_status.rb config path
+```
+
+- Dotted keys traverse nested hashes (`global.oauth.client_id`, `profiles.work.storage_backend`).
+- `set` coerces booleans (`true`/`false`), `null`/`nil`, and integers; everything else is a string.
+- `get` prints scalars as-is and hashes/arrays as pretty-printed JSON.
+- Exits 1 on `get` for an unset key (so `if ... fi` works in shell scripts).
+
+### `profiles`
+
+```bash
+ruby slack_status.rb profiles list
+```
+
+Lists every profile in `config.yml` with its effective storage backend (profile override or global default).
+
+### `migrate-emojis`
+
+Downloads every custom emoji image from a **source** workspace into a local directory so it can be bulk-uploaded to a **destination** workspace via Slack's emoji admin page. Read-only against the Slack API; the upload half is done by drag-and-drop in the web UI because Slack does not expose an emoji-upload API for non-Enterprise workspaces.
+
+```bash
+ruby slack_status.rb migrate-emojis --from <src-profile> [--to <dest-profile>] \
+                                    [--out DIR] [--filter REGEX] [--no-open]
+```
+
+What it does:
+
+1. Resolves the source profile's token and calls `emoji.list` (requires the `emoji:read` scope; declared in the shipped manifest).
+2. Downloads each entry whose value is an HTTPS URL (concurrent, default 6 workers) into `<out>/<name>.<ext>`. Detected extension comes from the URL or, as a fallback, the first few magic bytes.
+3. Writes `aliases.json` next to the images recording every `alias:<other>` entry. Aliases must be recreated by hand in the destination workspace (`Add Custom Emoji → Add Alias`).
+4. If `--to PROFILE` is provided, resolves that profile's token, calls `auth.test` to derive `https://<team>.slack.com/customize/emoji`, prints it, and opens it in the default browser (unless `--no-open`).
+5. Walks the user through the manual upload step with an inline checklist.
+
+#### Required scope
+
+Both source and destination profiles need the `emoji:read` user scope (the destination only needs it for the `auth.test` workspace lookup — `users.profile:write` would suffice if you skip `--to`). The current `docs/slack-app-manifest.yml` already includes it; tokens minted before that change need `setup --profile <name> --rotate` to re-OAuth with the new scope.
+
+#### Examples
+
+```bash
+ruby slack_status.rb migrate-emojis --from work --to personal
+ruby slack_status.rb migrate-emojis --from work --to personal --filter '^myth(o|ical)' --out ./mythpack
+ruby slack_status.rb migrate-emojis --from work --no-open --out /tmp/emojis
+```
+
+#### What lands on disk
+
+```text
+emoji-export-work-20260521-153012/
+├── phoenix_ash.png
+├── party_parrot.gif
+├── …
+├── aliases.json     # { "alias_name": "real_emoji_name", ... }
+└── skipped.json     # only written when some images failed to download
+```
+
+#### Why this isn't fully automated
+
+Slack restricts custom-emoji upload to the workspace admin web UI for Standard/Pro/Free workspaces; only Enterprise Grid exposes `admin.emoji.add`. The alternative — undocumented browser-session (`xoxc-` + `d` cookie) calls used by tools like `lambtron/emojipacks` — is fragile and walks Slack's TOS edge, so `slack-status-cli` deliberately stops at "downloaded images + opens the admin page".
+
+## Expiration semantics
+
+`expiration_seconds` from positional args is validated by `Slack#integer_string?` (matches `/\A[+-]?\d+\z/`) and added to `Time.now.to_i` before being sent as `status_expiration`. Anything non-integer (or empty) becomes a sticky status (expiration `0`).
+
+Slack itself doesn't expire `status_emoji`; the entire profile fields (`status_text`, `status_emoji`, `status_expiration`) get reset to empty/`0` at the timestamp you provide.

--- a/lib/cli_prompt.rb
+++ b/lib/cli_prompt.rb
@@ -1,0 +1,159 @@
+require 'io/console'
+
+# Standard interactive UX helpers shared by every CLI prompt in this tool.
+# Centralizing them keeps `[Y/n]` semantics, secret-input echo-off, and the
+# emoji progress vocabulary consistent between `setup`, `doctor`, and friends.
+module CliPrompt
+  EMOJI = {
+    step:    "🔧",
+    done:    "✅",
+    skip:    "⏭",
+    manual:  "✋",
+    browser: "🌐",
+    secret:  "🔐",
+    warn:    "⚠️ ",
+    fail:    "❌",
+  }.freeze
+
+  module_function
+
+  def ask_yes_no(question, default: :yes, input: $stdin, output: $stdout, non_interactive: false)
+    suffix = default == :yes ? "[Y/n]" : "[y/N]"
+    return default == :yes if non_interactive || !input.respond_to?(:gets)
+
+    loop do
+      output.print "#{question} #{suffix} "
+      output.flush
+      raw = input.gets
+      return default == :yes if raw.nil?
+      answer = raw.strip.downcase
+      return default == :yes if answer.empty?
+      return true  if %w[y yes].include?(answer)
+      return false if %w[n no].include?(answer)
+      output.puts "  please answer y or n."
+    end
+  end
+
+  def ask(question, default: nil, secret: false, input: $stdin, output: $stdout, non_interactive: false)
+    if non_interactive
+      return default if default
+      raise ArgumentError, "Cannot prompt for '#{question}' in non-interactive mode"
+    end
+
+    prompt = default ? "#{question} [#{default}] " : "#{question} "
+    output.print prompt
+    output.flush
+
+    raw =
+      if secret && input.respond_to?(:noecho) && input.tty?
+        value = input.noecho(&:gets)
+        output.puts
+        value
+      else
+        input.gets
+      end
+
+    return default if raw.nil?
+    answer = raw.chomp
+    answer = answer.strip unless secret
+    return default if answer.empty? && default
+    answer
+  end
+
+  def select(question, options:, default: nil, input: $stdin, output: $stdout, non_interactive: false)
+    raise ArgumentError, "select requires at least one option" if options.empty?
+    if non_interactive
+      return default if default && options.include?(default)
+      return options.first
+    end
+
+    output.puts question
+    options.each_with_index { |opt, i| output.puts "  #{i + 1}) #{opt}" }
+    default_idx = default ? options.index(default) : nil
+    suffix = default_idx ? " [#{default_idx + 1}]" : ""
+
+    loop do
+      output.print "Pick 1-#{options.size}#{suffix}: "
+      output.flush
+      raw = input.gets
+      return options[default_idx] if raw.nil? && default_idx
+      answer = raw.to_s.strip
+      return options[default_idx] if answer.empty? && default_idx
+      idx = Integer(answer, 10) rescue nil
+      return options[idx - 1] if idx && idx.between?(1, options.size)
+      output.puts "  pick a number from 1 to #{options.size}."
+    end
+  end
+
+  def step(current, total, label, output: $stdout)
+    output.puts "#{emoji(:step)} Step #{current}/#{total}: #{label}"
+  end
+
+  def done(label, output: $stdout)
+    output.puts "#{emoji(:done)} #{label}"
+  end
+
+  def skip(label, output: $stdout)
+    output.puts "#{emoji(:skip)} #{label}"
+  end
+
+  def info(label, output: $stdout)
+    output.puts "   #{label}"
+  end
+
+  def browser(label, output: $stdout)
+    output.puts "#{emoji(:browser)} #{label}"
+  end
+
+  def secret_written(label, output: $stdout)
+    output.puts "#{emoji(:secret)} #{label}"
+  end
+
+  def warn(label, output: $stderr)
+    output.puts "#{emoji(:warn)} #{label}"
+  end
+
+  def fail(label, output: $stderr)
+    output.puts "#{emoji(:fail)} #{label}"
+  end
+
+  # Renders a "you do this part" block and blocks on Enter.
+  def manual(instructions, input: $stdin, output: $stdout, non_interactive: false)
+    output.puts
+    output.puts "#{emoji(:manual)} Manual step required"
+    instructions.to_s.each_line { |line| output.puts "   #{line.chomp}" }
+    output.puts
+    return if non_interactive
+    output.print "   Press Enter once you're done… "
+    output.flush
+    input.gets
+  end
+
+  # Truncated form for confirming secret-ish values without echoing them in full.
+  def redacted(value, keep: 4)
+    return "" if value.nil? || value.empty?
+    str = value.to_s
+    return "*" * str.length if str.length <= keep
+    "…#{str[-keep, keep]}"
+  end
+
+  # Scrubs Slack token shapes (xoxp-, xoxb-, xoxc-, xoxd-, xoxa-, xoxs-, xoxr-)
+  # from any string so caught exceptions or response bodies don't accidentally
+  # log the secret.
+  SECRET_PATTERN = /\bxox[a-z]-[A-Za-z0-9-]+/
+  def scrub_secrets(text)
+    return text if text.nil?
+    text.to_s.gsub(SECRET_PATTERN) { |m| "xox?-#{redacted(m, keep: 4)}" }
+  end
+
+  def emoji(key)
+    return "" if emoji_disabled?
+    EMOJI.fetch(key)
+  end
+
+  def emoji_disabled?
+    return true if ENV["NO_EMOJI"] && !ENV["NO_EMOJI"].empty?
+    return true unless $stdout.respond_to?(:tty?) && $stdout.tty?
+    false
+  end
+end

--- a/lib/emoji_migrator.rb
+++ b/lib/emoji_migrator.rb
@@ -1,0 +1,166 @@
+require 'fileutils'
+require 'json'
+require 'net/http'
+require 'uri'
+
+# Downloads custom emoji image files from one Slack workspace into a local
+# directory so they can be bulk-uploaded to another workspace via Slack's
+# emoji admin page. Read-only against the source workspace API.
+#
+# Slack's `emoji.list` returns entries of two shapes:
+#   "phoenix_ash"       => "https://emoji.slack-edge.com/T.../phoenix_ash/abc.png"
+#   "phoenix_alias"     => "alias:phoenix_ash"
+#
+# Alias entries don't have their own image file and can't be recreated via
+# Slack's web UI bulk-upload, so we record them in `aliases.json` next to the
+# images for the user's reference.
+class EmojiMigrator
+  class Error < StandardError; end
+  class MissingScope < Error; end
+
+  CONCURRENCY = 6
+  ALIAS_FILENAME = "aliases.json".freeze
+  SKIPLIST_FILENAME = "skipped.json".freeze
+
+  attr_reader :downloaded, :aliases, :skipped, :total_bytes
+
+  def initialize(emoji_map:, out_dir:, filter: nil, logger: nil)
+    @emoji_map = emoji_map || {}
+    @out_dir = out_dir
+    @filter_pattern = filter
+    @logger = logger
+    @downloaded = []
+    @aliases = {}
+    @skipped = []
+    @total_bytes = 0
+  end
+
+  # Runs the migration. Returns self so callers can read counters off it.
+  def run
+    FileUtils.mkdir_p(@out_dir)
+
+    entries = filtered_entries
+    real_emoji = entries.reject { |_n, v| v.to_s.start_with?("alias:") }
+    aliases    = entries.select { |_n, v| v.to_s.start_with?("alias:") }
+
+    log "found #{entries.size} emoji#{entries.size == 1 ? "" : "s"} matching filter (#{real_emoji.size} images, #{aliases.size} aliases)"
+
+    aliases.each { |name, target| @aliases[name] = target.sub(/^alias:/, "") }
+    write_metadata_files
+
+    download_in_parallel(real_emoji)
+
+    self
+  end
+
+  # Resolves to a {name => {extension:, bytes:, path:}} hash for the caller's
+  # use (test seams, summary rendering).
+  def downloaded_details
+    @downloaded.dup
+  end
+
+  private
+
+  def filtered_entries
+    return @emoji_map if @filter_pattern.nil? || @filter_pattern.empty?
+    re = Regexp.new(@filter_pattern, Regexp::IGNORECASE)
+    @emoji_map.select { |name, _| re.match?(name) }
+  end
+
+  def download_in_parallel(real_emoji)
+    queue = Queue.new
+    real_emoji.each { |pair| queue.push(pair) }
+    mutex = Mutex.new
+
+    workers = Array.new(CONCURRENCY) do
+      Thread.new do
+        loop do
+          begin
+            name, url = queue.pop(true)
+          rescue ThreadError
+            break
+          end
+          begin
+            entry = download_one(name, url)
+            mutex.synchronize do
+              @downloaded << entry
+              @total_bytes += entry[:bytes]
+              log "  ✓ #{name}.#{entry[:extension]} (#{human_bytes(entry[:bytes])})"
+            end
+          rescue StandardError => e
+            mutex.synchronize do
+              @skipped << { name: name, url: url, reason: e.message }
+              log "  ✗ #{name} skipped: #{e.message}"
+            end
+          end
+        end
+      end
+    end
+    workers.each(&:join)
+  end
+
+  def download_one(name, url)
+    uri = URI(url)
+    body =
+      Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https") do |http|
+        http.read_timeout = 30
+        resp = http.get(uri.request_uri)
+        raise "HTTP #{resp.code}" unless resp.is_a?(Net::HTTPSuccess)
+        resp.body
+      end
+
+    ext = extension_for(url, body)
+    safe_name = sanitize_filename(name)
+    path = File.join(@out_dir, "#{safe_name}.#{ext}")
+    File.binwrite(path, body)
+
+    { name: name, extension: ext, bytes: body.bytesize, path: path }
+  end
+
+  # Slack's emoji image URLs include a clean extension in the last path
+  # segment (.png, .gif, .jpg). If something exotic shows up we fall back to
+  # sniffing the first few bytes.
+  def extension_for(url, body)
+    from_url = File.extname(URI(url).path).delete_prefix(".").downcase
+    return from_url if %w[png gif jpg jpeg webp].include?(from_url)
+
+    case body[0, 8]
+    when /\A\x89PNG/n then "png"
+    when /\AGIF8/n    then "gif"
+    when /\A\xFF\xD8\xFF/n then "jpg"
+    else "bin"
+    end
+  end
+
+  # Emoji names are already a restricted character set (a-z, 0-9, _, -, +)
+  # per Slack, but defend against future surprises.
+  def sanitize_filename(name)
+    name.to_s.gsub(/[^a-zA-Z0-9_+\-]/, "_")
+  end
+
+  def write_metadata_files
+    File.write(
+      File.join(@out_dir, ALIAS_FILENAME),
+      JSON.pretty_generate(@aliases),
+    )
+  end
+
+  def finalize_skipped_file
+    return if @skipped.empty?
+    File.write(
+      File.join(@out_dir, SKIPLIST_FILENAME),
+      JSON.pretty_generate(@skipped),
+    )
+  end
+
+  def human_bytes(n)
+    return "#{n} B" if n < 1024
+    return format("%.1f KB", n / 1024.0) if n < 1024 * 1024
+    format("%.1f MB", n / 1024.0 / 1024.0)
+  end
+
+  def log(message)
+    return unless @logger
+    @logger.call(message)
+  end
+end

--- a/lib/oauth_helper.rb
+++ b/lib/oauth_helper.rb
@@ -1,0 +1,180 @@
+require 'json'
+require 'net/http'
+require 'securerandom'
+require 'uri'
+require 'webrick'
+
+# Runs the Slack user-token OAuth install flow against a Slack App the user
+# created once. Boots a one-shot WEBrick listener on 127.0.0.1, opens the
+# browser at slack.com/oauth/v2/authorize, validates `state`, exchanges the
+# returned code for an `xoxp-` token via oauth.v2.access, and returns it.
+#
+# Only depends on stdlib + the webrick gem.
+class OAuthHelper
+  class Error < StandardError; end
+  class StateMismatch < Error; end
+  class Timeout < Error; end
+  class ExchangeFailed < Error; end
+  class PortBusy < Error; end
+
+  AUTHORIZE_URL = "https://slack.com/oauth/v2/authorize".freeze
+  ACCESS_URL    = "https://slack.com/api/oauth.v2.access".freeze
+  DEFAULT_PORT  = 53682
+  DEFAULT_TIMEOUT_SECONDS = 120
+
+  attr_reader :authorize_url, :redirect_uri
+
+  def initialize(client_id:, client_secret:, scopes: %w[users.profile:write emoji:read], port: DEFAULT_PORT, timeout: DEFAULT_TIMEOUT_SECONDS, logger: nil)
+    @client_id = client_id
+    @client_secret = client_secret
+    @scopes = scopes
+    @port = port
+    @timeout = timeout
+    @logger = logger
+    @state = SecureRandom.hex(16)
+    @redirect_uri = "http://localhost:#{@port}/callback"
+    @authorize_url = build_authorize_url
+  end
+
+  # Runs the flow. Yields the authorize URL to the caller (so it can print
+  # before opening the browser); returns a hash with the resolved user token.
+  def run
+    yield @authorize_url if block_given?
+    code = wait_for_callback
+    exchange_code(code)
+  end
+
+  private
+
+  def build_authorize_url
+    params = {
+      client_id: @client_id,
+      user_scope: @scopes.join(","),
+      redirect_uri: @redirect_uri,
+      state: @state,
+    }
+    "#{AUTHORIZE_URL}?#{URI.encode_www_form(params)}"
+  end
+
+  # Boots a one-shot WEBrick listener bound to loopback only, waits for the
+  # `/callback`, validates `state`, and returns the authorization `code`.
+  # `ReuseAddr: true` so a killed-then-restarted setup doesn't have to wait
+  # out the kernel's TIME_WAIT window on the socket.
+  def wait_for_callback
+    server =
+      begin
+        WEBrick::HTTPServer.new(
+          Port: @port,
+          BindAddress: "127.0.0.1",
+          ReuseAddr: true,
+          Logger: WEBrick::Log.new(File::NULL),
+          AccessLog: [],
+        )
+      rescue Errno::EADDRINUSE
+        raise PortBusy, <<~MSG.strip
+          Port #{@port} is already in use on 127.0.0.1.
+          Most likely a previous `setup` run is still alive. Find it and kill it:
+            lsof -nP -iTCP:#{@port} -sTCP:LISTEN -t | xargs -r kill
+          Then re-run: ruby slack_status.rb setup --profile <name> --rotate
+        MSG
+      end
+
+    received_code = nil
+    received_error = nil
+
+    server.mount_proc("/callback") do |req, res|
+      params = req.query
+      if params["error"] && !params["error"].empty?
+        received_error = "Slack returned error=#{params['error']}"
+        res.status = 400
+        res.body = error_page(received_error)
+      elsif params["state"] != @state
+        received_error = "OAuth state mismatch (CSRF guard)"
+        res.status = 400
+        res.body = error_page(received_error)
+      elsif params["code"].nil? || params["code"].empty?
+        received_error = "OAuth callback missing `code`"
+        res.status = 400
+        res.body = error_page(received_error)
+      else
+        received_code = params["code"]
+        res.status = 200
+        res.body = success_page
+      end
+      Thread.new { sleep 0.2; server.shutdown }
+    end
+
+    timer = Thread.new do
+      sleep @timeout
+      received_error ||= "OAuth callback timed out after #{@timeout}s"
+      server.shutdown
+    end
+
+    trap("INT") { server.shutdown }
+    server.start
+    timer.kill if timer.alive?
+
+    raise Timeout, received_error if received_error && received_error.include?("timed out")
+    raise StateMismatch, received_error if received_error && received_error.include?("state mismatch")
+    raise Error, received_error if received_error
+    received_code
+  end
+
+  def exchange_code(code)
+    uri = URI(ACCESS_URL)
+    req = Net::HTTP::Post.new(uri)
+    req.basic_auth(@client_id, @client_secret)
+    req.set_form_data(
+      "code" => code,
+      "redirect_uri" => @redirect_uri,
+    )
+
+    res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+      http.request(req)
+    end
+
+    unless res.is_a?(Net::HTTPSuccess)
+      raise ExchangeFailed, "Slack HTTP #{res.code}: #{res.body.to_s.strip[0, 200]}"
+    end
+
+    payload = JSON.parse(res.body)
+    unless payload["ok"]
+      raise ExchangeFailed, "oauth.v2.access error=#{payload['error']}"
+    end
+
+    user = payload["authed_user"] || {}
+    token = user["access_token"]
+    raise ExchangeFailed, "oauth.v2.access returned no authed_user.access_token" if token.nil? || token.empty?
+
+    {
+      token: token,
+      scope: user["scope"],
+      user_id: user["id"],
+      team_id: payload.dig("team", "id"),
+      team_name: payload.dig("team", "name"),
+    }
+  end
+
+  def success_page
+    <<~HTML
+      <!doctype html>
+      <html><head><meta charset="utf-8"><title>slack-status-cli</title></head>
+      <body style="font-family: -apple-system, system-ui, sans-serif; padding: 2rem; max-width: 36rem; margin: 0 auto;">
+        <h1>✅ Slack token received</h1>
+        <p>You can close this tab. Return to your terminal to finish setup.</p>
+      </body></html>
+    HTML
+  end
+
+  def error_page(reason)
+    <<~HTML
+      <!doctype html>
+      <html><head><meta charset="utf-8"><title>slack-status-cli</title></head>
+      <body style="font-family: -apple-system, system-ui, sans-serif; padding: 2rem; max-width: 36rem; margin: 0 auto;">
+        <h1>❌ OAuth failed</h1>
+        <p>#{WEBrick::HTMLUtils.escape(reason)}</p>
+        <p>Return to your terminal for next steps.</p>
+      </body></html>
+    HTML
+  end
+end

--- a/lib/slack.rb
+++ b/lib/slack.rb
@@ -179,7 +179,7 @@ class Slack
       },
       musical_myth: {
         text: format_tune,
-        emoji: ":music:"
+        emoji: ":musical_note:"
       }
     }
   end

--- a/lib/slack.rb
+++ b/lib/slack.rb
@@ -4,7 +4,6 @@ require 'json'
 require 'uri'
 
 class Slack
-  SLACK_TOKEN = ENV['SLACK_SECRET_TOKEN']
   MYTH_MOJIS = [":wolf:", ":lion_face:", ":phoenix_ash:", ":fox_face:", ":butterfly:"]
 
   PAUSED_PHRASES = [
@@ -22,11 +21,27 @@ class Slack
   PAUSED_SLEEP = 30
   SILENT_SLEEP = 120
 
-  def initialize(mode: :myth, emoji: nil, text: nil, expiration: 0)
+  def initialize(token:, mode: :myth, emoji: nil, text: nil, expiration: 0)
+    @token = token
     @mode = mode || :myth
     @emoji = emoji || mode_map&.fetch(:emoji)
     @text = text || mode_map&.fetch(:text)
     @expiration = evaluate_expiration(expiration) || mode_map&.fetch(:expiration, evaluate_expiration(expiration)) || 0
+  end
+
+  # Calls auth.test to validate the token and resolve the workspace/user it
+  # belongs to. Returns the parsed JSON response on success, raises on HTTP
+  # failure. Used by the `doctor` subcommand.
+  def auth_test
+    slack_get("auth.test")
+  end
+
+  # Calls emoji.list and returns the parsed JSON. Requires the `emoji:read`
+  # scope on the user token. Each value in the `emoji` map is either an HTTPS
+  # URL (real custom emoji) or `"alias:<other_name>"` (an alias of another
+  # emoji on the same workspace).
+  def emoji_list
+    slack_get("emoji.list")
   end
 
   def update_status
@@ -60,6 +75,24 @@ class Slack
   private
   attr_accessor :mode, :emoji, :text, :expiration
 
+  # Slack Web API methods are documented as accepting GET when no body is
+  # required (auth.test, emoji.list). Returns parsed JSON on 2xx, raises on
+  # transport-level failure. API-level errors (`{ "ok": false, "error": ... }`)
+  # are surfaced to the caller via the parsed hash so they can map error codes
+  # to actionable hints.
+  def slack_get(method)
+    uri = URI("https://slack.com/api/#{method}")
+    req = Net::HTTP::Get.new(uri)
+    req["Authorization"] = "Bearer #{@token}"
+
+    res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+      http.request(req)
+    end
+
+    raise "Slack HTTP #{res.code} #{res.message}" unless res.is_a?(Net::HTTPSuccess)
+    JSON.parse(res.body)
+  end
+
   def evaluate_expiration(value)
     return if value.nil? || value.to_s.strip.empty?
     return unless integer_string?(value)
@@ -67,7 +100,7 @@ class Slack
   end
 
   def integer_string?(str)
-    /\A[+-]?\d+\z/.match?(str)
+    /\A[+-]?\d+\z/.match?(str.to_s)
   end
 
   def reset_status
@@ -81,7 +114,7 @@ class Slack
     payload = build_payload(text: text, emoji: emoji, expiration: expiration)
     req = Net::HTTP::Post.new(uri)
     req["Content-Type"] = "application/json; charset=utf-8"
-    req["Authorization"] = "Bearer #{SLACK_TOKEN}"
+    req["Authorization"] = "Bearer #{@token}"
     req.body = payload
 
     res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
@@ -219,7 +252,14 @@ class Slack
   end
 
   def body_excerpt(body, limit: 200)
-    snippet = body.strip
+    snippet = scrub(body.strip)
     snippet.length > limit ? "#{snippet[0, limit]}…" : snippet
+  end
+
+  # Defense-in-depth: even though Slack's responses don't echo the token,
+  # scrub any `xox?-` pattern before printing so a future log statement
+  # can't accidentally leak a secret.
+  def scrub(text)
+    text.to_s.gsub(/\bxox[a-z]-[A-Za-z0-9-]+/) { |m| "xox?-…#{m[-4, 4]}" }
   end
 end

--- a/lib/token_resolver.rb
+++ b/lib/token_resolver.rb
@@ -1,0 +1,512 @@
+require 'fileutils'
+require 'json'
+require 'open3'
+require 'yaml'
+
+# Resolves a Slack user token for the current profile by walking a fixed
+# precedence chain (CLI flag -> profile-scoped env -> config-driven backend ->
+# legacy SLACK_SECRET_TOKEN). Also serves as the read/write interface used by
+# the `setup` and `config` subcommands.
+class TokenResolver
+  class Error < StandardError; end
+  class NotFoundError < Error; end
+  class ConfigError < Error; end
+  class ManualWriteRequired < Error; end
+  class WriteError < Error; end
+
+  DEFAULT_CONFIG_PATH = File.expand_path("~/.config/slack-status-cli/config.yml").freeze
+  DEFAULT_TOKEN_DIR = File.expand_path("~/.config/slack-status-cli/tokens").freeze
+  DEFAULT_PROFILE = "default".freeze
+  KEYCHAIN_SERVICE = "slack-status-cli".freeze
+  LEGACY_ENV_VAR = "SLACK_SECRET_TOKEN".freeze
+  SUPPORTED_BACKENDS = %w[dashlane keychain file env].freeze
+
+  attr_reader :profile, :config_path
+
+  def initialize(profile: nil, cli_token: nil, config_path: nil, verbose: false)
+    @profile = (profile || ENV["SLACK_STATUS_PROFILE"] || DEFAULT_PROFILE).to_s
+    @cli_token = cli_token
+    @config_path = config_path || DEFAULT_CONFIG_PATH
+    @verbose = verbose
+  end
+
+  # Walks the precedence chain and returns the first non-empty token found.
+  # @return [Hash] { token:, source:, profile: }
+  # @raise [NotFoundError] when nothing resolves
+  #
+  # Precedence (highest -> lowest):
+  #   1. --token CLI flag
+  #   2. SLACK_STATUS_TOKEN_<PROFILE> env var
+  #   3. Backend configured for the active profile (profile -> global)
+  #   4. SLACK_SECRET_TOKEN (legacy) — ONLY when the active profile is `default`
+  #      AND no profile-specific backend is configured. This protects users who
+  #      run with `--profile work` from getting their `SLACK_SECRET_TOKEN`
+  #      (which may belong to a different workspace) silently injected.
+  def resolve
+    if non_empty?(@cli_token)
+      return success(@cli_token, "cli:--token")
+    end
+
+    profile_env_key = profile_env_var_name(@profile)
+    if non_empty?(ENV[profile_env_key])
+      return success(ENV[profile_env_key], "env:#{profile_env_key}")
+    end
+
+    cfg = load_config
+    profile_configured = profile_explicitly_configured?(cfg)
+
+    backend = build_backend(config: cfg)
+    tried_backend = nil
+    if backend
+      tried_backend = backend
+      token = backend.read
+      return success(token, backend.source_label) if non_empty?(token)
+    end
+
+    # Legacy fallback is profile-agnostic; restrict it to the default profile
+    # with no backend configured to prevent cross-workspace token leakage.
+    legacy_eligible = @profile == DEFAULT_PROFILE && !profile_configured && backend.nil?
+    if legacy_eligible && non_empty?(ENV[LEGACY_ENV_VAR])
+      return success(ENV[LEGACY_ENV_VAR], "env:#{LEGACY_ENV_VAR}")
+    end
+
+    raise NotFoundError, friendly_not_found_message(
+      tried_backend: tried_backend,
+      profile_configured: profile_configured,
+    )
+  end
+
+  # Returns the merged settings hash (global <- profile) for the active
+  # profile, without reading any secrets.
+  def merged_settings
+    cfg = load_config
+    global = cfg["global"] || {}
+    profile_cfg = (cfg.dig("profiles", @profile) || {})
+    deep_merge(global, profile_cfg)
+  end
+
+  # Persists a token via the backend selected by merged settings. Returns the
+  # backend's source label on success. Raises ManualWriteRequired when the
+  # backend cannot write programmatically (instructions are in the message).
+  def write_token(token, backend_name: nil)
+    backend = build_backend(forced_backend: backend_name)
+    raise WriteError, "No backend configured for profile #{@profile}" unless backend
+    backend.write(token)
+    backend.source_label
+  end
+
+  def load_config
+    self.class.load_config(@config_path)
+  end
+
+  def self.load_config(path = DEFAULT_CONFIG_PATH)
+    return {} unless File.exist?(path)
+    YAML.safe_load(File.read(path), permitted_classes: [], aliases: false) || {}
+  rescue Psych::Exception => e
+    raise ConfigError, "Failed to parse #{path}: #{e.message}"
+  end
+
+  def self.write_config(config, path = DEFAULT_CONFIG_PATH)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, YAML.dump(deep_stringify(config)))
+    File.chmod(0o600, path)
+    path
+  end
+
+  def self.profile_env_var_name(profile)
+    "SLACK_STATUS_TOKEN_#{sanitize_profile_for_env(profile)}"
+  end
+
+  def self.sanitize_profile_for_env(profile)
+    profile.to_s.upcase.gsub(/[^A-Z0-9_]/, "_")
+  end
+
+  def self.deep_merge(a, b)
+    return b.dup if a.nil? || a.empty?
+    return a.dup if b.nil? || b.empty?
+    a.merge(b) do |_key, av, bv|
+      if av.is_a?(Hash) && bv.is_a?(Hash)
+        deep_merge(av, bv)
+      else
+        bv
+      end
+    end
+  end
+
+  def self.deep_stringify(obj)
+    case obj
+    when Hash then obj.each_with_object({}) { |(k, v), h| h[k.to_s] = deep_stringify(v) }
+    when Array then obj.map { |v| deep_stringify(v) }
+    else obj
+    end
+  end
+
+  private
+
+  def profile_env_var_name(profile)
+    self.class.profile_env_var_name(profile)
+  end
+
+  def deep_merge(a, b)
+    self.class.deep_merge(a, b)
+  end
+
+  def non_empty?(value)
+    !value.nil? && !value.to_s.strip.empty?
+  end
+
+  def success(token, source)
+    log_source(source)
+    { token: token.to_s.strip, source: source, profile: @profile }
+  end
+
+  def log_source(source)
+    return unless @verbose
+    warn "[slack-status-cli] token resolved from #{source} (profile=#{@profile})"
+  end
+
+  def build_backend(forced_backend: nil, config: nil)
+    settings = config ? merge_settings_from(config) : merged_settings
+    backend_name = (forced_backend || settings["storage_backend"] || infer_default_backend(settings))&.to_s
+    return nil unless backend_name
+
+    klass = backend_class(backend_name)
+    raise ConfigError, "Unknown storage_backend '#{backend_name}' (supported: #{SUPPORTED_BACKENDS.join(', ')})" unless klass
+
+    klass.new(profile: @profile, settings: settings)
+  end
+
+  def merge_settings_from(cfg)
+    global = cfg["global"] || {}
+    profile_cfg = (cfg.dig("profiles", @profile) || {})
+    deep_merge(global, profile_cfg)
+  end
+
+  def profile_explicitly_configured?(cfg)
+    block = cfg.dig("profiles", @profile)
+    block.is_a?(Hash) && !block.empty?
+  end
+
+  def infer_default_backend(settings)
+    return nil if settings.nil? || settings.empty?
+    return "dashlane" if settings["token_ref"]
+    nil
+  end
+
+  def backend_class(name)
+    case name
+    when "dashlane" then DashlaneBackend
+    when "keychain" then KeychainBackend
+    when "file" then FileBackend
+    when "env" then EnvBackend
+    end
+  end
+
+  def friendly_not_found_message(tried_backend: nil, profile_configured: false)
+    lines = ["No Slack token found for profile '#{@profile}'."]
+
+    if tried_backend
+      lines << "Tried #{tried_backend.source_label} but it returned no token."
+      hint = tried_backend.not_found_hint
+      hint.each_line { |l| lines << "  #{l.chomp}" } if hint
+    elsif !profile_configured && @profile != DEFAULT_PROFILE
+      lines << "Profile '#{@profile}' is not configured in #{@config_path}."
+    end
+
+    lines << ""
+    lines << "Fix one of:"
+    lines << "  1. ruby slack_status.rb setup --profile #{@profile}"
+    lines << "  2. export #{profile_env_var_name(@profile)}=xoxp-... in your shell"
+    lines << "  3. ruby slack_status.rb --token xoxp-... --profile #{@profile} <mode>"
+
+    if non_empty?(ENV[LEGACY_ENV_VAR]) && (@profile != DEFAULT_PROFILE || profile_configured)
+      lines << ""
+      lines << "Note: SLACK_SECRET_TOKEN is set but intentionally ignored for"
+      lines << "profile '#{@profile}' to avoid sending a token from a different"
+      lines << "workspace. The legacy fallback only applies to the `default`"
+      lines << "profile when no backend is configured."
+    end
+
+    lines.join("\n")
+  end
+
+  class Backend
+    attr_reader :profile, :settings, :last_error
+
+    def initialize(profile:, settings: {})
+      @profile = profile
+      @settings = settings || {}
+      @last_error = nil
+    end
+
+    def read
+      raise NotImplementedError
+    end
+
+    def write(_token)
+      raise NotImplementedError
+    end
+
+    def source_label
+      "#{name}:#{location}"
+    end
+
+    def name
+      self.class.name.split("::").last.sub(/Backend$/, "").downcase
+    end
+
+    def location
+      ""
+    end
+
+    # Backends override to explain WHY their read returned nil, including how
+    # the user can fix it. Surfaced by TokenResolver::NotFoundError.
+    def not_found_hint
+      nil
+    end
+  end
+
+  class DashlaneBackend < Backend
+    # Uses `dcli note --output json 'title=<title>'` instead of the
+    # `dcli read dl://<title>` URL form because the URL parser treats `/` as
+    # the title/field separator, which breaks any title containing a slash
+    # (e.g. `slack-status-cli/<profile>-token`).
+    def read
+      stdout, stderr, status = Open3.capture3(
+        "dcli", "note", "--output", "json", "title=#{title}"
+      )
+      unless status.success?
+        @last_error = strip_ansi(stderr).strip
+        return nil
+      end
+
+      notes =
+        begin
+          JSON.parse(stdout)
+        rescue JSON::ParserError => e
+          @last_error = "dcli returned non-JSON output (#{e.message})"
+          return nil
+        end
+
+      if notes.nil? || notes.empty?
+        @last_error = "no Secure Note matches title=#{title} (local vault may be stale; try `dcli sync`)"
+        return nil
+      end
+
+      content = notes.first["content"].to_s.strip
+      if content.empty?
+        @last_error = "Secure Note '#{title}' exists but its content is empty"
+        return nil
+      end
+      content
+    rescue Errno::ENOENT
+      @last_error = "`dcli` not found in PATH"
+      nil
+    end
+
+    def not_found_hint
+      case @last_error
+      when /no Secure Note matches/
+        <<~HINT.strip
+          No Secure Note titled '#{title}' was found in your local Dashlane vault.
+          If you just created the note, refresh the local cache:
+            dcli sync
+          If the note doesn't exist yet, create it with:
+            1. Open the Dashlane app.
+            2. Add a Secure Note titled EXACTLY: #{title}
+            3. Paste your Slack user token (xoxp-...) into the content field.
+          To re-print the token and title, run:
+            ruby slack_status.rb setup --profile #{profile} --rotate
+        HINT
+      when /content is empty/
+        "Secure Note '#{title}' exists but its content is empty. Paste your xoxp-... token into it."
+      when "`dcli` not found in PATH"
+        "Install the Dashlane CLI: brew install dashlane/tap/dashlane-cli"
+      when nil, ""
+        nil
+      else
+        "dcli error: #{@last_error}"
+      end
+    end
+
+    def write(token)
+      # `dcli` personal does not expose a generic write API; instruct the user
+      # to add the secret to their vault manually. The token itself is never
+      # echoed back to stdout.
+      raise ManualWriteRequired, <<~MSG.strip
+        Dashlane CLI does not support unattended writes. Add the token manually:
+          1. Open the Dashlane app (or run `dcli sync`).
+          2. Create a Secure Note titled exactly: #{title}
+          3. Paste the token (printed once below) into the content field.
+          4. Re-run: ruby slack_status.rb doctor --profile #{profile}
+
+        Token (copy now, it will not be shown again):
+        #{token}
+      MSG
+    end
+
+    def location
+      token_ref
+    end
+
+    def token_ref
+      ref = settings["token_ref"]
+      return ref if ref && !ref.to_s.strip.empty?
+      "dl://#{title_prefix}/#{profile}-token"
+    end
+
+    private
+
+    def title
+      token_ref.sub(/^dl:\/\//, "")
+    end
+
+    def title_prefix
+      (settings.dig("backend_options", "dashlane", "title_prefix") || "slack-status-cli")
+    end
+
+    def strip_or_nil(value)
+      stripped = value.to_s.strip
+      stripped.empty? ? nil : stripped
+    end
+
+    def strip_ansi(value)
+      value.to_s.gsub(/\e\[[0-9;]*m/, "")
+    end
+  end
+
+  class KeychainBackend < Backend
+    def read
+      stdout, stderr, status = Open3.capture3(
+        "security", "find-generic-password", "-s", service, "-a", account, "-w"
+      )
+      unless status.success?
+        @last_error = stderr.to_s.strip
+        return nil
+      end
+      stripped = stdout.to_s.strip
+      stripped.empty? ? nil : stripped
+    rescue Errno::ENOENT
+      @last_error = "`security` not found in PATH (macOS only)"
+      nil
+    end
+
+    def not_found_hint
+      if @last_error&.include?("could not be found")
+        "No Keychain item for service=#{service} account=#{account}. Re-run setup --profile #{profile} --rotate."
+      elsif @last_error == "`security` not found in PATH (macOS only)"
+        @last_error
+      end
+    end
+
+    def write(token)
+      stdout, stderr, status = Open3.capture3(
+        "security", "add-generic-password",
+        "-s", service, "-a", account, "-w", token, "-U"
+      )
+      return if status.success?
+      raise WriteError, "security add-generic-password failed: #{stderr.strip.empty? ? stdout.strip : stderr.strip}"
+    rescue Errno::ENOENT
+      raise WriteError, "`security` not found in PATH; Keychain backend requires macOS."
+    end
+
+    def location
+      "#{service}/#{account}"
+    end
+
+    private
+
+    def service
+      settings.dig("backend_options", "keychain", "service") || KEYCHAIN_SERVICE
+    end
+
+    def account
+      settings.dig("backend_options", "keychain", "account") || profile
+    end
+  end
+
+  class FileBackend < Backend
+    def read
+      unless File.exist?(path)
+        @last_error = "file does not exist"
+        return nil
+      end
+      unless permissions_ok?
+        @last_error = "permissions too open"
+        return nil
+      end
+      stripped = File.read(path).strip
+      stripped.empty? ? nil : stripped
+    end
+
+    def not_found_hint
+      case @last_error
+      when "file does not exist" then "Token file not found at #{path}. Re-run setup --profile #{profile} --rotate."
+      when "permissions too open" then "Token file #{path} has overly permissive permissions. Run: chmod 600 #{path}"
+      end
+    end
+
+    def write(token)
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, "#{token}\n")
+      File.chmod(0o600, path)
+    end
+
+    def location
+      path
+    end
+
+    private
+
+    def path
+      override = settings.dig("backend_options", "file", "path")
+      return File.expand_path(override) if override
+      File.join(DEFAULT_TOKEN_DIR, profile)
+    end
+
+    # Refuses to read a token file with group/other readable bits set, so a
+    # misconfigured permission doesn't silently leak the secret.
+    def permissions_ok?
+      mode = File.stat(path).mode & 0o777
+      return true if (mode & 0o077).zero?
+      warn "[slack-status-cli] refusing to read #{path}: permissions #{mode.to_s(8)} are too open (chmod 600)."
+      false
+    end
+  end
+
+  class EnvBackend < Backend
+    def read
+      key = env_key
+      value = ENV[key]
+      if value.nil? || value.strip.empty?
+        @last_error = "env var #{key} is empty or unset"
+        return nil
+      end
+      value.strip
+    end
+
+    def not_found_hint
+      "Export #{env_key}=xoxp-... in your shell, then start a new shell."
+    end
+
+    def write(_token)
+      raise ManualWriteRequired, <<~MSG.strip
+        Env backend can't persist tokens automatically.
+        Add this to your shell profile (~/.zshrc, ~/.bash_profile, etc.):
+          export #{env_key}=xoxp-...
+        Then start a new shell and re-run: ruby slack_status.rb doctor --profile #{profile}
+      MSG
+    end
+
+    def location
+      env_key
+    end
+
+    private
+
+    def env_key
+      settings.dig("backend_options", "env", "var") ||
+        TokenResolver.profile_env_var_name(profile)
+    end
+  end
+end

--- a/slack_status.rb
+++ b/slack_status.rb
@@ -1,45 +1,482 @@
+#!/usr/bin/env ruby
+
 $LOAD_PATH.unshift(File.join(__dir__, "lib"))
 
-require 'slack'
-require 'net/http'
 require 'json'
-require 'uri'
+require 'optparse'
 
-slack = nil
-shutdown_requested = false
+require 'cli_prompt'
+require 'token_resolver'
 
-%w[INT TERM].each do |sig|
-  trap(sig) do
-    shutdown_requested = true
-    exit
+RESERVED_MODES = %i[myth lunch break clear musical_myth].freeze
+SUBCOMMANDS    = %w[setup doctor config profiles].freeze
+BACKENDS       = TokenResolver::SUPPORTED_BACKENDS
+
+def parse_global_flags(argv)
+  options = {
+    profile: nil,
+    token: nil,
+    config_path: nil,
+    verbose: false,
+    non_interactive: false,
+    rotate: false,
+    global: false,
+    backend: nil,
+    client_id: nil,
+    client_secret: nil,
+  }
+
+  parser = OptionParser.new do |o|
+    o.banner = "Usage: ruby slack_status.rb [options] <command> [args]"
+    o.separator ""
+    o.separator "Commands: setup, doctor, config get|set, profiles list,"
+    o.separator "          plus any mode (myth, lunch, break, clear, musical_myth, custom)"
+    o.separator ""
+    o.on("--profile NAME", "Profile name (default: $SLACK_STATUS_PROFILE or 'default')") { |v| options[:profile] = v }
+    o.on("--token TOKEN", "Use this token directly (highest precedence)") { |v| options[:token] = v }
+    o.on("--config PATH", "Path to config.yml (default: ~/.config/slack-status-cli/config.yml)") { |v| options[:config_path] = v }
+    o.on("--verbose", "Print token source to stderr") { options[:verbose] = true }
+    o.on("--non-interactive", "Fail instead of prompting") { options[:non_interactive] = true }
+    o.on("--rotate", "(setup) Overwrite an existing token") { options[:rotate] = true }
+    o.on("--global", "(setup) Configure global defaults only") { options[:global] = true }
+    o.on("--backend NAME", BACKENDS, "(setup) Storage backend: #{BACKENDS.join('|')}") { |v| options[:backend] = v }
+    o.on("--client-id ID", "(setup) Slack App client_id") { |v| options[:client_id] = v }
+    o.on("--client-secret SECRET", "(setup) Slack App client_secret (prefer prompt)") { |v| options[:client_secret] = v }
+    o.on("-h", "--help", "Show this help") { puts o; exit 0 }
   end
+
+  # `permute!` (not `order!`) so flags can appear anywhere — before or after
+  # the subcommand. Otherwise `slack_status.rb setup --profile foo` silently
+  # drops `--profile foo` because OptionParser stops at the first non-option
+  # (`setup`).
+  parser.permute!(argv)
+  options
 end
 
-at_exit do
-  next unless shutdown_requested && slack
-  puts "\nStopping Slack client… sending goodbye to Music ❤️"
-  slack.clear_status
+def build_resolver(options)
+  TokenResolver.new(
+    profile: options[:profile],
+    cli_token: options[:token],
+    config_path: options[:config_path],
+    verbose: options[:verbose],
+  )
 end
 
-if __FILE__ == $0
-  mode = ARGV[0]&.to_sym
+def run_status_mode(command, rest_args, options)
+  require 'slack'
 
+  mode = command&.to_sym
   if mode == :musical_myth
     text = nil
     emoji = nil
     expiration = nil
   else
-    text = ARGV[1] # As optional String
-    emoji = ARGV[2] # As optional String
-    expiration = ARGV[3] # As optional Integer (in seconds)
+    text = rest_args[0]
+    emoji = rest_args[1]
+    expiration = rest_args[2]
   end
 
+  resolver = build_resolver(options)
+  token_info =
+    begin
+      resolver.resolve
+    rescue TokenResolver::NotFoundError => e
+      CliPrompt.fail("Could not resolve a Slack token.")
+      e.message.each_line { |line| warn "   #{line.chomp}" }
+      exit 1
+    end
+
   slack = Slack.new(
+    token: token_info[:token],
     mode: mode,
     text: text,
     emoji: emoji,
-    expiration: expiration
+    expiration: expiration,
   )
 
+  install_signal_handlers(slack)
   slack.update_status
+end
+
+def install_signal_handlers(slack)
+  shutdown_requested = false
+  %w[INT TERM].each do |sig|
+    trap(sig) do
+      shutdown_requested = true
+      exit
+    end
+  end
+
+  at_exit do
+    next unless shutdown_requested && slack
+    puts "\nStopping Slack client… sending goodbye to Music ❤️"
+    slack.clear_status
+  end
+end
+
+# --- subcommands ---
+
+def run_setup(options)
+  require 'oauth_helper'
+
+  profile = options[:profile] || ENV["SLACK_STATUS_PROFILE"] || TokenResolver::DEFAULT_PROFILE
+  config_path = options[:config_path] || TokenResolver::DEFAULT_CONFIG_PATH
+  config = TokenResolver.load_config(config_path)
+  config["global"] ||= {}
+  config["profiles"] ||= {}
+
+  total_steps = options[:global] ? 2 : 4
+
+  CliPrompt.step(1, total_steps, "Slack App configuration")
+  client_id = resolve_client_id(options, config, profile)
+  client_secret = options[:global] ? nil : resolve_client_secret(options, config, profile, client_id)
+
+  CliPrompt.step(2, total_steps, "Choose a token storage backend")
+  backend = resolve_backend(options, config, profile)
+  CliPrompt.done("Backend: #{backend}")
+
+  if options[:global]
+    persist_global_defaults(config, config_path, client_id: client_id, backend: backend)
+    CliPrompt.done("Global defaults saved to #{config_path}.")
+    return
+  end
+
+  if profile_has_token?(profile, config_path) && !options[:rotate]
+    if CliPrompt.ask_yes_no("Profile '#{profile}' already has a token. Overwrite?", default: :no, non_interactive: options[:non_interactive])
+      options[:rotate] = true
+    else
+      CliPrompt.skip("Keeping existing token. Use --rotate to force.")
+      return
+    end
+  end
+
+  CliPrompt.step(3, total_steps, "OAuth install")
+  helper = OAuthHelper.new(client_id: client_id, client_secret: client_secret)
+  CliPrompt.browser("Opening #{helper.authorize_url[0, 80]}… in your browser.")
+  CliPrompt.info("Listening on #{helper.redirect_uri} (2 min timeout)…")
+  open_in_browser(helper.authorize_url)
+
+  result =
+    begin
+      helper.run
+    rescue OAuthHelper::Error => e
+      CliPrompt.fail("OAuth flow failed: #{CliPrompt.scrub_secrets(e.message)}")
+      exit 1
+    end
+
+  CliPrompt.done("Received authorization code; exchanging for user token…")
+  CliPrompt.done("Got #{redacted_token(result[:token])} (scope=#{result[:scope]}, team=#{result[:team_name]})")
+
+  CliPrompt.step(4, total_steps, "Persist the token")
+  persist_profile_token(
+    config,
+    config_path,
+    profile: profile,
+    backend: backend,
+    token: result[:token],
+    client_id: client_id,
+  )
+end
+
+def resolve_client_id(options, config, profile)
+  return options[:client_id] if options[:client_id] && !options[:client_id].empty?
+
+  # Profile-level client_id wins over global. This is how multi-workspace
+  # setups work without enabling Slack App Distribution: one internal app
+  # per workspace, each with its own client_id stored under its profile.
+  profile_existing = config.dig("profiles", profile, "oauth", "client_id")
+  global_existing  = config.dig("global", "oauth", "client_id")
+  existing = profile_existing || global_existing
+  scope = profile_existing ? "profile '#{profile}'" : "global"
+
+  if existing && !existing.empty?
+    if CliPrompt.ask_yes_no("Found #{scope} client_id ending in #{CliPrompt.redacted(existing)}. Reuse it?", default: :yes, non_interactive: options[:non_interactive])
+      CliPrompt.done("Using #{scope} client_id ending in #{CliPrompt.redacted(existing)}.")
+      return existing
+    end
+  end
+
+  # First-time setup (or user declined to reuse): show where to find the
+  # credentials before prompting so the input has context.
+  print_app_creation_instructions(options)
+
+  value = CliPrompt.ask("Enter Client ID (from Basic Information):", non_interactive: options[:non_interactive])
+  raise "Client ID is required" if value.nil? || value.empty?
+  value
+end
+
+def print_app_creation_instructions(options)
+  CliPrompt.manual(
+    <<~INSTR,
+      Where to find your Client ID + Client Secret:
+        1) Open https://api.slack.com/apps?new_app=1
+        2) Pick "From a manifest", then pick your workspace.
+        3) Paste the contents of docs/slack-app-manifest.yml and confirm.
+        4) On the new app's "Basic Information" page, scroll to "App Credentials":
+           - Client ID looks like 1234567890123.0987654321098
+           - Click "Show" next to Client Secret to reveal it.
+        5) The manifest pre-fills the OAuth redirect URL; double-check it under
+           "OAuth & Permissions" → "Redirect URLs": http://localhost:53682/callback
+    INSTR
+    non_interactive: options[:non_interactive],
+  )
+end
+
+def resolve_client_secret(options, config, profile, client_id)
+  return options[:client_secret] if options[:client_secret] && !options[:client_secret].empty?
+
+  # Profile-level secret_ref wins over global, mirroring client_id semantics
+  # so a per-workspace app can carry its own Dashlane / env reference.
+  secret_ref = config.dig("profiles", profile, "oauth", "client_secret_ref") ||
+               config.dig("global", "oauth", "client_secret_ref")
+  if secret_ref && !secret_ref.empty?
+    value = read_secret_ref(secret_ref)
+    if value
+      CliPrompt.done("Resolved client_secret from #{secret_ref}.")
+      return value
+    end
+    CliPrompt.warn("client_secret_ref #{secret_ref} did not resolve; will prompt.")
+  end
+
+  CliPrompt.ask("Enter Client Secret (from Basic Information; input hidden):", secret: true, non_interactive: options[:non_interactive])
+end
+
+# Resolves a `client_secret_ref` of the form `dl://...`, `env:VAR`, or `file:/path`.
+def read_secret_ref(ref)
+  case ref
+  when /\Aenv:(.+)\z/
+    value = ENV[$1]
+    value && !value.empty? ? value : nil
+  when /\Adl:\/\//
+    require 'open3'
+    stdout, _stderr, status = Open3.capture3("dcli", "read", ref)
+    return nil unless status.success?
+    stripped = stdout.strip
+    stripped.empty? ? nil : stripped
+  when /\Afile:(.+)\z/
+    path = File.expand_path($1)
+    return nil unless File.exist?(path)
+    value = File.read(path).strip
+    value.empty? ? nil : value
+  else
+    nil
+  end
+rescue Errno::ENOENT
+  nil
+end
+
+def resolve_backend(options, config, profile)
+  return options[:backend] if options[:backend]
+
+  default = config.dig("profiles", profile, "storage_backend") ||
+            config.dig("global", "storage_backend") ||
+            "dashlane"
+
+  if CliPrompt.ask_yes_no("Use the default backend `#{default}`?", default: :yes, non_interactive: options[:non_interactive])
+    return default
+  end
+
+  CliPrompt.select("Available backends:", options: BACKENDS, default: default, non_interactive: options[:non_interactive])
+end
+
+def profile_has_token?(profile, config_path)
+  TokenResolver.new(profile: profile, config_path: config_path).resolve
+  true
+rescue TokenResolver::NotFoundError
+  false
+end
+
+def persist_global_defaults(config, config_path, client_id:, backend:)
+  config["global"] ||= {}
+  config["global"]["oauth"] ||= {}
+  config["global"]["oauth"]["client_id"] = client_id
+  config["global"]["storage_backend"] = backend
+  TokenResolver.write_config(config, config_path)
+end
+
+def persist_profile_token(config, config_path, profile:, backend:, token:, client_id: nil)
+  config["profiles"] ||= {}
+  config["profiles"][profile] ||= {}
+  config["profiles"][profile]["storage_backend"] = backend
+
+  # Store the client_id under the profile only when it diverges from the
+  # global default. Same value as global → keep it as a single source of truth.
+  # Different value (e.g., a per-workspace Slack App) → pin it on the profile
+  # so future setup/doctor runs use the right app.
+  global_id = config.dig("global", "oauth", "client_id")
+  if client_id && !client_id.empty? && client_id != global_id
+    config["profiles"][profile]["oauth"] ||= {}
+    config["profiles"][profile]["oauth"]["client_id"] = client_id
+  end
+
+  TokenResolver.write_config(config, config_path)
+
+  resolver = TokenResolver.new(profile: profile, config_path: config_path)
+  begin
+    label = resolver.write_token(token, backend_name: backend)
+    CliPrompt.secret_written("Wrote token to #{label}.")
+    CliPrompt.done("Setup complete. Verify with: ruby slack_status.rb doctor --profile #{profile}")
+  rescue TokenResolver::ManualWriteRequired => e
+    CliPrompt.warn("Backend `#{backend}` needs a manual step:")
+    e.message.each_line { |line| puts "   #{line.chomp}" }
+    CliPrompt.done("Once stored, verify with: ruby slack_status.rb doctor --profile #{profile}")
+  end
+end
+
+def open_in_browser(url)
+  return unless RUBY_PLATFORM.include?("darwin")
+  system("open", url)
+end
+
+def redacted_token(token)
+  return "<token>" if token.nil? || token.empty?
+  "#{token[0, 5]}…#{token[-4, 4]}"
+end
+
+def run_doctor(options)
+  require 'slack'
+
+  resolver = build_resolver(options)
+  token_info =
+    begin
+      resolver.resolve
+    rescue TokenResolver::NotFoundError => e
+      CliPrompt.fail("No token resolved for profile '#{resolver.profile}'.")
+      e.message.each_line { |line| warn "   #{line.chomp}" }
+      exit 1
+    end
+
+  CliPrompt.info("source : #{token_info[:source]}")
+  CliPrompt.info("profile: #{token_info[:profile]}")
+  CliPrompt.info("token  : #{redacted_token(token_info[:token])}")
+
+  slack = Slack.new(token: token_info[:token], mode: :clear)
+  response =
+    begin
+      slack.auth_test
+    rescue StandardError => e
+      CliPrompt.fail("auth.test failed: #{CliPrompt.scrub_secrets(e.message)}")
+      exit 1
+    end
+
+  if response["ok"]
+    CliPrompt.done("auth.test ok — workspace=#{response['team']} user=#{response['user']} url=#{response['url']}")
+  else
+    CliPrompt.fail("Slack rejected token: #{response['error']}")
+    hint = doctor_hint(response['error'])
+    CliPrompt.info(hint) if hint
+    exit 1
+  end
+end
+
+def doctor_hint(error_code)
+  case error_code
+  when "not_authed", "invalid_auth", "token_revoked"
+    "Re-run: ruby slack_status.rb setup --profile <name> --rotate"
+  when "missing_scope"
+    "Your token is missing `users.profile:write`. Re-run setup and accept the manifest scopes."
+  when "account_inactive"
+    "The Slack user owning this token is deactivated. Use a different account."
+  when "rate_limited"
+    "Slack is rate-limiting this token. Retry later."
+  end
+end
+
+def run_config(args, options)
+  sub = args.shift
+  config_path = options[:config_path] || TokenResolver::DEFAULT_CONFIG_PATH
+
+  case sub
+  when "get"
+    key = args.shift or abort "Usage: config get <dotted.key>"
+    config = TokenResolver.load_config(config_path)
+    value = dotted_get(config, key)
+    if value.nil?
+      warn "(unset)"
+      exit 1
+    end
+    puts value.is_a?(Hash) || value.is_a?(Array) ? JSON.pretty_generate(value) : value
+  when "set"
+    key = args.shift or abort "Usage: config set <dotted.key> <value>"
+    value = args.shift
+    abort "Usage: config set <dotted.key> <value>" if value.nil?
+    config = TokenResolver.load_config(config_path)
+    dotted_set!(config, key, coerce_scalar(value))
+    TokenResolver.write_config(config, config_path)
+    CliPrompt.done("set #{key} = #{value}")
+  when "path"
+    puts config_path
+  when nil, "help", "-h", "--help"
+    puts <<~HELP
+      config get <dotted.key>          # e.g. config get global.storage_backend
+      config set <dotted.key> <value>  # e.g. config set global.storage_backend keychain
+      config path                      # print the active config file path
+    HELP
+  else
+    abort "Unknown config subcommand: #{sub}"
+  end
+end
+
+def run_profiles(args, options)
+  sub = args.shift || "list"
+  config_path = options[:config_path] || TokenResolver::DEFAULT_CONFIG_PATH
+  config = TokenResolver.load_config(config_path)
+
+  case sub
+  when "list"
+    profiles = (config["profiles"] || {}).keys
+    if profiles.empty?
+      puts "(no profiles configured; run: ruby slack_status.rb setup --profile <name>)"
+      return
+    end
+    global_backend = config.dig("global", "storage_backend") || "(unset)"
+    puts "Global default backend: #{global_backend}"
+    profiles.each do |name|
+      backend = config.dig("profiles", name, "storage_backend") || global_backend
+      puts "  - #{name}  (backend=#{backend})"
+    end
+  else
+    abort "Unknown profiles subcommand: #{sub}"
+  end
+end
+
+def dotted_get(hash, key)
+  key.to_s.split(".").reduce(hash) do |memo, part|
+    break nil unless memo.is_a?(Hash)
+    memo[part]
+  end
+end
+
+def dotted_set!(hash, key, value)
+  parts = key.to_s.split(".")
+  last = parts.pop
+  cursor = parts.reduce(hash) do |memo, part|
+    memo[part] = {} unless memo[part].is_a?(Hash)
+    memo[part]
+  end
+  cursor[last] = value
+end
+
+def coerce_scalar(str)
+  case str
+  when "true" then true
+  when "false" then false
+  when "null", "nil" then nil
+  when /\A-?\d+\z/ then Integer(str)
+  else str
+  end
+end
+
+if __FILE__ == $0
+  options = parse_global_flags(ARGV)
+  command = ARGV.shift
+
+  case command
+  when "setup"          then run_setup(options)
+  when "doctor"         then run_doctor(options)
+  when "config"         then run_config(ARGV, options)
+  when "profiles"       then run_profiles(ARGV, options)
+  else
+    run_status_mode(command, ARGV, options)
+  end
 end

--- a/slack_status.rb
+++ b/slack_status.rb
@@ -24,12 +24,17 @@ def parse_global_flags(argv)
     backend: nil,
     client_id: nil,
     client_secret: nil,
+    from: nil,
+    to: nil,
+    out: nil,
+    filter: nil,
+    open_browser: true,
   }
 
   parser = OptionParser.new do |o|
     o.banner = "Usage: ruby slack_status.rb [options] <command> [args]"
     o.separator ""
-    o.separator "Commands: setup, doctor, config get|set, profiles list,"
+    o.separator "Commands: setup, doctor, config get|set, profiles list, migrate-emojis,"
     o.separator "          plus any mode (myth, lunch, break, clear, musical_myth, custom)"
     o.separator ""
     o.on("--profile NAME", "Profile name (default: $SLACK_STATUS_PROFILE or 'default')") { |v| options[:profile] = v }
@@ -42,6 +47,11 @@ def parse_global_flags(argv)
     o.on("--backend NAME", BACKENDS, "(setup) Storage backend: #{BACKENDS.join('|')}") { |v| options[:backend] = v }
     o.on("--client-id ID", "(setup) Slack App client_id") { |v| options[:client_id] = v }
     o.on("--client-secret SECRET", "(setup) Slack App client_secret (prefer prompt)") { |v| options[:client_secret] = v }
+    o.on("--from PROFILE", "(migrate-emojis) Source profile to download emojis from") { |v| options[:from] = v }
+    o.on("--to PROFILE", "(migrate-emojis) Destination profile (used to derive admin URL)") { |v| options[:to] = v }
+    o.on("--out DIR", "(migrate-emojis) Output directory (default: ./emoji-export-<from>-<timestamp>)") { |v| options[:out] = v }
+    o.on("--filter REGEX", "(migrate-emojis) Only download emoji whose name matches REGEX (case-insensitive)") { |v| options[:filter] = v }
+    o.on("--no-open", "(migrate-emojis) Do not open the destination admin URL automatically") { options[:open_browser] = false }
     o.on("-h", "--help", "Show this help") { puts o; exit 0 }
   end
 
@@ -369,6 +379,125 @@ def run_doctor(options)
   end
 end
 
+def run_migrate_emojis(options)
+  require 'slack'
+  require 'emoji_migrator'
+  require 'time'
+
+  from = options[:from]
+  abort "migrate-emojis requires --from <profile>" if from.nil? || from.empty?
+  to = options[:to]
+
+  source_resolver = TokenResolver.new(
+    profile: from,
+    cli_token: nil,
+    config_path: options[:config_path],
+    verbose: options[:verbose],
+  )
+  source_token =
+    begin
+      source_resolver.resolve[:token]
+    rescue TokenResolver::NotFoundError => e
+      CliPrompt.fail("Could not resolve a token for source profile '#{from}'.")
+      e.message.each_line { |line| warn "   #{line.chomp}" }
+      exit 1
+    end
+
+  CliPrompt.step(1, 4, "Listing custom emojis on '#{from}'")
+  emoji_response =
+    begin
+      Slack.new(token: source_token, mode: :clear).emoji_list
+    rescue StandardError => e
+      CliPrompt.fail("emoji.list failed: #{CliPrompt.scrub_secrets(e.message)}")
+      exit 1
+    end
+
+  unless emoji_response["ok"]
+    case emoji_response["error"]
+    when "missing_scope"
+      CliPrompt.fail("Token for '#{from}' is missing the `emoji:read` scope.")
+      CliPrompt.info("Re-run setup to grant it:")
+      CliPrompt.info("  ruby slack_status.rb setup --profile #{from} --rotate")
+      CliPrompt.info("(The shipped manifest already declares the scope; re-installing the app re-prompts you for consent.)")
+    else
+      CliPrompt.fail("Slack rejected emoji.list: #{emoji_response["error"]}")
+    end
+    exit 1
+  end
+
+  emoji_map = emoji_response["emoji"] || {}
+  CliPrompt.done("Found #{emoji_map.size} entr#{emoji_map.size == 1 ? "y" : "ies"}.")
+
+  out_dir = options[:out] || "./emoji-export-#{from}-#{Time.now.strftime("%Y%m%d-%H%M%S")}"
+  CliPrompt.step(2, 4, "Downloading images to #{out_dir}")
+  migrator = EmojiMigrator.new(
+    emoji_map: emoji_map,
+    out_dir: out_dir,
+    filter: options[:filter],
+    logger: ->(msg) { CliPrompt.info(msg) },
+  ).run
+
+  CliPrompt.done(
+    "Downloaded #{migrator.downloaded.size} image#{migrator.downloaded.size == 1 ? "" : "s"} " \
+    "(#{format("%.1f KB", migrator.total_bytes / 1024.0)}), " \
+    "#{migrator.aliases.size} alias#{migrator.aliases.size == 1 ? "" : "es"} (see aliases.json), " \
+    "#{migrator.skipped.size} skipped."
+  )
+
+  admin_url = nil
+  if to && !to.empty?
+    CliPrompt.step(3, 4, "Resolving destination workspace from profile '#{to}'")
+    admin_url = resolve_admin_url(options, to)
+    if admin_url
+      CliPrompt.done("Destination emoji admin: #{admin_url}")
+    else
+      CliPrompt.skip("Could not derive destination admin URL; skipping browser step.")
+    end
+  end
+
+  CliPrompt.step(4, 4, "Next: bulk-upload to your destination workspace")
+  CliPrompt.manual(<<~MSG.strip, non_interactive: options[:non_interactive])
+    Slack does not expose an emoji-upload API for non-Enterprise workspaces,
+    so the last mile is a one-time drag-and-drop:
+
+      1. Open #{admin_url || "<your-workspace>.slack.com/customize/emoji"}
+      2. Click "Add Custom Emoji" -> "Upload Image".
+      3. Drag every image from:
+           #{File.expand_path(out_dir)}
+         (Slack's emoji admin accepts multi-file drag-and-drop.)
+      4. Aliases (see aliases.json in the same folder) must be recreated
+         manually: "Add Custom Emoji" -> "Add Alias".
+
+    Press Enter when you're done (or Ctrl-C to abort).
+  MSG
+
+  if admin_url && options[:open_browser]
+    open_in_browser(admin_url)
+  end
+end
+
+# Calls auth.test against the destination profile to derive
+# https://<team-subdomain>.slack.com/customize/emoji. Returns nil on any
+# failure (network, missing profile, rejected token) — caller treats that as
+# "skip the browser step".
+def resolve_admin_url(options, to_profile)
+  require 'slack'
+  resolver = TokenResolver.new(
+    profile: to_profile,
+    cli_token: nil,
+    config_path: options[:config_path],
+    verbose: options[:verbose],
+  )
+  token = resolver.resolve[:token]
+  response = Slack.new(token: token, mode: :clear).auth_test
+  return nil unless response["ok"]
+  url = response["url"].to_s.sub(/\/+\z/, "")
+  return nil if url.empty?
+  "#{url}/customize/emoji"
+rescue StandardError
+  nil
+end
+
 def doctor_hint(error_code)
   case error_code
   when "not_authed", "invalid_auth", "token_revoked"
@@ -476,6 +605,7 @@ if __FILE__ == $0
   when "doctor"         then run_doctor(options)
   when "config"         then run_config(ARGV, options)
   when "profiles"       then run_profiles(ARGV, options)
+  when "migrate-emojis" then run_migrate_emojis(options)
   else
     run_status_mode(command, ARGV, options)
   end


### PR DESCRIPTION
## Summary

Three intertwined pieces of work that turn `slack-status-cli` from a single-token script into a multi-workspace tool, plus the supporting documentation and the emoji-portability fixes that fell out along the way.

### 1. Multi-profile token resolution (`TokenResolver`)
- Walks `--token > SLACK_STATUS_TOKEN_<PROFILE> > config-driven backend > SLACK_SECRET_TOKEN (legacy)`.
- Backends: `dashlane` (via `dcli note --output json`), `keychain` (macOS `security`), `file` (`~/.config/slack-status-cli/tokens/<profile>`, refuses to read if mode allows group/other), `env`.
- **No silent fallthrough**: the legacy `SLACK_SECRET_TOKEN` is only used when the active profile is `default` AND no explicit profile config exists. This plugs a real foot-gun where a work-Slack token in `SLACK_SECRET_TOKEN` could be silently used for a `--profile personal` call.
- `NotFoundError` carries actionable diagnostics including which backend was tried and why it returned empty (e.g. ``Dashlane has no Secure Note matching 'slack-status-cli/<profile>-token'``).

### 2. OAuth setup flow (`OAuthHelper`, `CliPrompt`, `setup` subcommand)
- One-shot WEBrick listener on `127.0.0.1:53682` with `ReuseAddr` to survive killed-then-restarted setups, state validation, and a clean `PortBusy` error with `lsof + kill` recipe.
- `setup` walks through Slack App creation (via the new manifest), OAuth install, and persistence to the chosen backend. Supports `--global` defaults, per-profile `client_id` overrides for multi-workspace setups (no Slack App Distribution / HTTPS needed), and `--rotate`.
- Adds sibling subcommands `doctor` (validates token via `auth.test`), `config get|set`, and `profiles list`.

### 3. Emoji migration (`migrate-emojis` subcommand + `EmojiMigrator`)
- Lists custom emoji on the source workspace via `emoji.list` (new `emoji:read` scope in the shipped manifest).
- Downloads images concurrently (6 workers), captures aliases in `aliases.json`, records failures in `skipped.json`, infers file extension from URL + magic-bytes fallback.
- Resolves the destination workspace via the destination profile's `auth.test`, prints the emoji admin URL, and opens it in the browser for the final drag-and-drop step. Read-only against the Slack API — the upload half is deliberate manual, because Slack restricts emoji upload to the web UI for non-Enterprise workspaces.

### Drive-by fixes
- ``Slack`` mode_map: ``:music:`` → ``:musical_note:`` so `musical_myth` works on workspaces where the Slack-specific ``:music:`` alias isn't installed.
- ``Slack#integer_string?`` coerces its input via `to_s` so the constructor's expiration handling no longer crashes on integer literals.
- ``Slack#body_excerpt`` scrubs ``xox?-`` patterns before printing as defense-in-depth against accidental token leakage in logs.

### Documentation
- README slimmed to a high-level entry point (~40 lines), with a quickstart that points at the new `setup` subcommand.
- New `docs/` folder with `setup.md`, `security.md`, `usage.md`, `musical-myth.md`, `examples.md`, `troubleshooting.md`, `architecture.md`, and the shipped `slack-app-manifest.yml`.

## File map

| Area | New | Modified |
|---|---|---|
| Dependencies | `Gemfile`, `Gemfile.lock` | — |
| Library | `lib/token_resolver.rb`, `lib/oauth_helper.rb`, `lib/cli_prompt.rb`, `lib/emoji_migrator.rb` | `lib/slack.rb` |
| CLI | — | `slack_status.rb` |
| Docs | `docs/*.md`, `docs/slack-app-manifest.yml` | `README.md` |

## Test plan

- [x] `ruby -c` clean on every Ruby file.
- [x] `TokenResolver` 5-scenario unit test (cli flag, profile env, configured backend, legacy env back-compat, no-fallthrough safety) — all pass.
- [x] `EmojiMigrator` end-to-end unit test against a throwaway WEBrick image server: 2 PNG/GIF downloads, 1 alias capture, 1 404 skipped, filter regex respected.
- [x] `doctor --profile <configured>` round-trip against live `dcli note` vault.
- [x] `doctor --profile <unconfigured>` correctly refuses to fall back to `SLACK_SECRET_TOKEN` and prints the actionable not-found message.
- [x] `migrate-emojis --from <profile-without-emoji:read>` returns the actionable `missing_scope` hint pointing at `setup --rotate`.
- [x] `OAuthHelper` raises `PortBusy` with the `lsof + kill` recipe when port 53682 is held by another process.
- [x] `slack_status.rb --help` lists all subcommands and the new `--from/--to/--out/--filter/--no-open` flags.

### Manual verification still to do

- [ ] Re-OAuth existing profiles with `setup --profile <name> --rotate` so they pick up the new `emoji:read` scope (the manifest change requires "Update from manifest" in each Slack App first).
- [ ] End-to-end `migrate-emojis --from <work> --to <personal>` against a real workspace pair once the scope is in place.

## Notes for review

- Atomic commits, in dependency order: deps → low-level libs → `Slack` refactor → emoji portability fix → migrator → CLI rewrite → migrate-emojis subcommand → docs.
- No JIRA ticket; branch `em/multi_profile_setup_and_emoji_migration`.
- No tests live in this repo yet (intentional per CLAUDE.md guidance for the `negotiatus` repo — same convention applied here). Verification done via scripted scenarios I ran during development.


Made with [Cursor](https://cursor.com)