### PR TITLE
T1.1 — RSpec + WebMock scaffold + Callable port

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--require spec_helper
+--format documentation
+--color

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,9 @@ ruby "~> 3.0"
 # WEBrick was extracted from stdlib in Ruby 3.0; the OAuth helper boots a
 # one-shot listener on 127.0.0.1 to capture the Slack redirect.
 gem "webrick", "~> 1.8"
+
+group :test do
+  gem "rspec", "~> 3.13"
+  gem "webmock", "~> 3.23"
+  gem "simplecov", "~> 0.22", require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,40 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    bigdecimal (4.1.2)
+    crack (1.0.1)
+      bigdecimal
+      rexml
+    diff-lcs (1.6.2)
+    docile (1.4.1)
+    hashdiff (1.2.1)
+    public_suffix (7.0.5)
+    rexml (3.4.4)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.9.2)
 
 PLATFORMS
@@ -8,6 +42,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  rspec (~> 3.13)
+  simplecov (~> 0.22)
+  webmock (~> 3.23)
   webrick (~> 1.8)
 
 RUBY VERSION

--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -1,0 +1,8 @@
+# Root namespace and autoload entry point for the slack-status-cli refactor.
+#
+# Every new Callable lives at `lib/slack_status_cli/<pod>/<...>.rb` and gets wired
+# in here as it ships, so `require "slack_status_cli"` is the single entry point
+# used by both `slack_status.rb` (the CLI dispatcher) and the spec_helper.
+module SlackStatusCli
+  autoload :Callable, "slack_status_cli/callable"
+end

--- a/lib/slack_status_cli/callable.rb
+++ b/lib/slack_status_cli/callable.rb
@@ -1,0 +1,51 @@
+# The Callable module provides a convenient method to instantiate and call service classes.
+# By extending this module, service classes gain a class-level `call` method that forwards
+# arguments to the initializer and then invokes the instance-level `call` method.
+#
+# Usage:
+#   1. Extend the `Callable` module in your service class.
+#   2. Define an `initialize` method in your service class to accept the necessary arguments.
+#   3. Define an instance-level `call` method that implements the service's functionality.
+#
+# Example:
+#   class MyService
+#     extend SlackStatusCli::Callable
+#
+#     def initialize(param1, param2)
+#       @param1 = param1
+#       @param2 = param2
+#     end
+#
+#     def call
+#       # Perform service logic here
+#       puts "Called with #{@param1} and #{@param2}"
+#     end
+#
+#     private
+#
+#     attr_reader :param1, :param2
+#   end
+#
+#   Instead of:
+#   MyService.new(param1, param2).call
+#
+#   You can simply do:
+#   MyService.call(param1, param2)
+#
+# The `call` method can accept any kind of arguments (positional, keyword, etc.)
+# and forwards them to the `initialize` method of the service class.
+module SlackStatusCli
+  module Callable
+    # Instantiates the service class and then forwards the arguments to its initialize.
+    #
+    # Usage:
+    #   MyService.call(param1, param2)
+    #
+    #   This is equivalent to:
+    #
+    #   MyService.new(param1, param2).call
+    def call(...)
+      new(...).call
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,27 @@
+require "webmock/rspec"
+
+# Block every real HTTP request — the Slack pod's specs whitelist endpoints
+# via `stub_request`, and nothing else should touch the network.
+WebMock.disable_net_connect!
+
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+require "slack_status_cli"
+
+# Support modules and shared fakes land in T1.2 / T1.3 under spec/support/**.
+# The glob is harmless until they exist.
+Dir[File.expand_path("support/**/*.rb", __dir__)].sort.each { |file| require file }
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.disable_monkey_patching!
+  config.order = :random
+  Kernel.srand(config.seed)
+end


### PR DESCRIPTION
Closes #7
Part of #6 (Epic 1 — TDD Foundation)

## Summary

Greenfield scaffolding only — lays down the test harness that every later pod's TDD red-gate will lean on. No domain code is touched and no spec files are added (those land in T1.2 / T1.3, per the issue's commit plan).

Three independently-green commits:

1. **`chore(test): Add RSpec + WebMock + SimpleCov to Gemfile`** — adds a `group :test` with `rspec ~> 3.13`, `webmock ~> 3.23`, `simplecov ~> 0.22` (gem ships with `require: false` since coverage wiring is deferred).
2. **`feat(infra): Add SlackStatusCli autoload root + Callable mixin port`** — verbatim port of pi-pod's `app/services/callable.rb`, nested under the `SlackStatusCli` namespace to avoid collisions. `lib/slack_status_cli.rb` only autoloads `Callable` for now; each subsequent task adds its pod's autoload line as it ships.
3. **`chore(test): Add .rspec + spec_helper.rb with WebMock disable_net_connect!`** — wires WebMock, adds `lib/` to `$LOAD_PATH`, requires `slack_status_cli`, pre-loads `spec/support/**/*.rb` (the dir is created by T1.2), plus standard RSpec config (`disable_monkey_patching!`, `:random` order, `verify_partial_doubles`).

## Test plan

This is a scaffolding task. The only "tests" are the acceptance gates in the issue body — all four pass:

- [x] `bundle install` exits 0
- [x] `bundle exec rspec` exits 0 with `0 examples, 0 failures`
- [x] `ruby -Ilib -rslack_status_cli -e 'puts SlackStatusCli::Callable'` prints `SlackStatusCli::Callable`
- [x] `git diff main -- lib/slack.rb lib/music.rb lib/cli_prompt.rb lib/emoji_migrator.rb lib/oauth_helper.rb lib/token_resolver.rb slack_status.rb` is empty (no domain code touched)

## Design notes (worth a second pair of eyes)

- **Namespaced `Callable`.** Pi-pod's source is top-level `module Callable`. Nested here as `SlackStatusCli::Callable` so this codebase doesn't collide with a Rails-app `Callable` if it ever gets vendored.
- **Minimal autoload tree.** Only `Callable` is wired. Future tasks add their own autoload lines as they introduce pod files — keeps each commit independently revertable and avoids dangling autoloads.
- **`simplecov` requires `require: false`.** SimpleCov has to be required *before* application code loads to instrument it, and there's no `bin/rspec` wrapper yet. The wrapper + require land in the coverage-badge task (Epic 8 territory).

## Out of scope

- Support modules (`StdioCapture`, `TmpConfig`, `factories.rb`) — T1.2 (#8)
- Shared fakes (`FakeShellRunner`, `FakeSleeper`) — T1.3 (#9)
- Any domain-class extraction — Epics 2-7

Made with [Cursor](https://cursor.com)