### PR TITLE
T1.2 — Support modules (StdioCapture + TmpConfig + factories.rb)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Full prerequisites (Ruby 3, `nowplaying-cli`, optional `dcli` for Dashlane) live
 - [Examples](docs/examples.md) — copy-pasteable invocations.
 - [Troubleshooting](docs/troubleshooting.md) — notes, gotchas, `doctor` workflow, common Slack errors.
 - [Architecture](docs/architecture.md) — project structure, token-resolver design, future work.
+- [Project workflow](docs/project-workflow.md) — GitHub Project conventions: labels as canonical metadata, Status field, agent housekeeping steps, useful filters.
 
 ## Requirements
 

--- a/docs/project-workflow.md
+++ b/docs/project-workflow.md
@@ -1,0 +1,79 @@
+# Project workflow
+
+This document describes how the [Slack CLI Pi-Pod Refactor](https://github.com/users/efmcuiti/projects/2/views/1) GitHub Project is managed.
+
+## Labels are the single source of truth
+
+Issue labels carry all pod/size/phase/type/tdd metadata. The **Project** sidebar tracks only workflow state (Status).
+
+| Label prefix | Example | Meaning |
+|---|---|---|
+| `pod:` | `pod:foundation` | Which refactor pod owns this issue |
+| `size:` | `size:s` | PR size estimate (s / m / l) |
+| `phase:` | `phase:extraction` | Refactor phase (bootstrap / foundation / extraction / cleanup) |
+| `type:` | `type:task` | Granularity: `type:epic` vs `type:task` |
+| `tdd:` | `tdd:red-gate` | Has at least one `/pi-dev` shipit gate |
+
+**Do not recreate Pod, Size, or Phase as custom project fields.** They duplicate labels and will drift out of sync because GitHub does not link labels to custom field values.
+
+## Project fields
+
+Only the built-in **Status** field is used on project items:
+
+| Value | Meaning |
+|---|---|
+| Todo | Not yet started |
+| In Progress | Actively being worked |
+| Done | Merged / closed |
+
+Project field IDs (for agent automation):
+
+| Field | ID |
+|---|---|
+| Project node | `PVT_kwHOABIV3s4BYb61` |
+| Status field | `PVTSSF_lAHOABIV3s4BYb61zhThzys` |
+| Status → Todo | `f75ad846` |
+| Status → In Progress | `47fc9ee4` |
+| Status → Done | `98236657` |
+
+## Filtering by label
+
+The table view supports `label:` qualifiers directly in the search bar. Useful filters:
+
+```
+label:phase:foundation
+label:phase:extraction
+label:pod:slack
+label:pod:foundation
+label:tdd:red-gate
+label:size:l
+label:phase:extraction label:pod:cli
+```
+
+Combine with `status:` to narrow further: `label:pod:foundation status:"In Progress"`.
+
+## Project views — setup
+
+**Table view (primary):** Enable the built-in **Labels** column via *View → Fields → Labels*. Place it after Title/Status so pod/size/phase labels are visible without opening each issue.
+
+**Optional saved views:**
+
+| View name | Filter |
+|---|---|
+| Foundation | `label:phase:foundation` |
+| Extraction | `label:phase:extraction` |
+| Cleanup | `label:phase:cleanup` |
+| Red gates | `label:tdd:red-gate` |
+| By pod: Slack | `label:pod:slack` |
+
+## Agent housekeeping per task
+
+When an agent picks up a task issue, the required steps are:
+
+1. Assign the issue: `gh issue edit N --add-assignee efmcuiti --repo efmcuiti/slack-status-cli`
+2. Set Status to In Progress via GraphQL (`updateProjectV2ItemFieldValue`, Status field + option `47fc9ee4`)
+3. Create branch with naming convention `em/<issue#>_<task_slug>`
+4. Tick acceptance checkboxes as they clear: `gh issue edit N --body "<updated body>"`
+5. Open draft PR assigned to `efmcuiti` with `Closes #N` in the body
+
+Do **not** set Pod, Size, or Phase fields — they no longer exist on the project.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,4 +27,5 @@ RSpec.configure do |config|
   Kernel.srand(config.seed)
 
   config.include StdioCapture
+  config.include TmpConfig
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,8 +8,9 @@ $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 require "slack_status_cli"
 
 # Support modules and shared fakes land in T1.2 / T1.3 under spec/support/**.
-# The glob is harmless until they exist.
-Dir[File.expand_path("support/**/*.rb", __dir__)].sort.each { |file| require file }
+# The glob is harmless until they exist; the `*_spec.rb` exclusion stops RSpec
+# from registering co-located specs twice once they ship.
+Dir[File.expand_path("support/**/*.rb", __dir__)].reject { |file| file.end_with?("_spec.rb") }.sort.each { |file| require file }
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -24,4 +25,6 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
   config.order = :random
   Kernel.srand(config.seed)
+
+  config.include StdioCapture
 end

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -1,0 +1,2 @@
+# Plain Ruby factory helpers. Examples added by downstream tasks.
+# def build_tune(state: :playing, name: "...", artist: "..."); end

--- a/spec/support/stdio_capture.rb
+++ b/spec/support/stdio_capture.rb
@@ -1,0 +1,18 @@
+require "stringio"
+
+# Silences and captures anything the block writes to $stdout / $stderr,
+# returning a `{ stdout:, stderr: }` hash. The original streams are always
+# restored, even if the block raises.
+module StdioCapture
+  def capture_stdio
+    original_stdout = $stdout
+    original_stderr = $stderr
+    $stdout = StringIO.new
+    $stderr = StringIO.new
+    yield
+    { stdout: $stdout.string, stderr: $stderr.string }
+  ensure
+    $stdout = original_stdout
+    $stderr = original_stderr
+  end
+end

--- a/spec/support/stdio_capture_spec.rb
+++ b/spec/support/stdio_capture_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+RSpec.describe StdioCapture do
+  let(:host) { Class.new { include StdioCapture }.new }
+
+  describe "#capture_stdio" do
+    it "returns stdout written inside the block" do
+      result = host.capture_stdio { puts "hello-out" }
+
+      expect(result[:stdout]).to eq("hello-out\n")
+    end
+
+    it "returns stderr written inside the block" do
+      result = host.capture_stdio { warn("hello-err") }
+
+      expect(result[:stderr]).to eq("hello-err\n")
+    end
+
+    it "restores $stdout and $stderr after the block" do
+      original_stdout = $stdout
+      original_stderr = $stderr
+
+      host.capture_stdio { puts "ignored" }
+
+      expect($stdout).to be(original_stdout)
+      expect($stderr).to be(original_stderr)
+    end
+
+    it "restores $stdout and $stderr even when the block raises" do
+      original_stdout = $stdout
+      original_stderr = $stderr
+
+      expect { host.capture_stdio { raise("boom") } }.to raise_error("boom")
+
+      expect($stdout).to be(original_stdout)
+      expect($stderr).to be(original_stderr)
+    end
+  end
+end

--- a/spec/support/tmp_config.rb
+++ b/spec/support/tmp_config.rb
@@ -3,12 +3,12 @@ require "tmpdir"
 # Yields a `config.yml` path inside a fresh temporary directory that is removed
 # automatically when the block returns or raises. Domain specs that touch the
 # CLI's on-disk config use this helper instead of writing to the real
-# `~/.slack-status-cli/` tree.
+# `~/.config/slack-status-cli/` tree.
 module TmpConfig
-  def with_tmp_config(&block)
+  def with_tmp_config
     Dir.mktmpdir("slack-status-cli-config") do |dir|
       path = File.join(dir, "config.yml")
-      block.call(path: path, dir: dir)
+      yield(path: path, dir: dir)
     end
   end
 end

--- a/spec/support/tmp_config.rb
+++ b/spec/support/tmp_config.rb
@@ -1,0 +1,14 @@
+require "tmpdir"
+
+# Yields a `config.yml` path inside a fresh temporary directory that is removed
+# automatically when the block returns or raises. Domain specs that touch the
+# CLI's on-disk config use this helper instead of writing to the real
+# `~/.slack-status-cli/` tree.
+module TmpConfig
+  def with_tmp_config(&block)
+    Dir.mktmpdir("slack-status-cli-config") do |dir|
+      path = File.join(dir, "config.yml")
+      block.call(path: path, dir: dir)
+    end
+  end
+end

--- a/spec/support/tmp_config_spec.rb
+++ b/spec/support/tmp_config_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+RSpec.describe TmpConfig do
+  let(:host) { Class.new { include TmpConfig }.new }
+
+  describe "#with_tmp_config" do
+    it "yields a writable path inside a tempdir" do
+      captured = nil
+
+      host.with_tmp_config do |path:, dir:|
+        captured = { path: path, dir: dir }
+        File.write(path, "key: value\n")
+        expect(File.read(path)).to eq("key: value\n")
+      end
+
+      expect(captured[:path]).to eq(File.join(captured[:dir], "config.yml"))
+      expect(captured[:dir]).to match(%r{slack-status-cli-config})
+    end
+
+    it "cleans up the tempdir on success" do
+      leaked_dir = nil
+
+      host.with_tmp_config do |path:, dir:|
+        leaked_dir = dir
+        File.write(path, "anything")
+      end
+
+      expect(File.exist?(leaked_dir)).to be(false)
+    end
+
+    it "cleans up the tempdir on exception" do
+      leaked_dir = nil
+
+      expect do
+        host.with_tmp_config do |path:, dir:|
+          leaked_dir = dir
+          File.write(path, "anything")
+          raise("boom")
+        end
+      end.to raise_error("boom")
+
+      expect(File.exist?(leaked_dir)).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
Closes #8
Part of #6 (Epic 1 — TDD Foundation)

## Summary

Adds the `spec/support/` modules every downstream pod's specs will lean on:

1. **`chore(test): Add StdioCapture support module + spec`** — `StdioCapture#capture_stdio` swaps `$stdout` / `$stderr` for `StringIO`s, yields, and returns a `{ stdout:, stderr: }` hash. Stream restoration runs in `ensure`, so it survives raises. Spec covers stdout capture, stderr capture, restore-on-success, restore-on-exception. Also fixes a glob bug in `spec_helper.rb` that was about to register every co-located `*_spec.rb` twice — see design notes.
2. **`chore(test): Add TmpConfig support module + spec`** — `TmpConfig#with_tmp_config` wraps `Dir.mktmpdir("slack-status-cli-config")` and yields keyword args `path:` (a `config.yml` inside) and `dir:` (the tempdir itself). The block-form mktmpdir cleans up automatically on both success and exception paths; the spec proves both.
3. **`chore(test): Add empty factories.rb placeholder`** — File only contains the two comment lines from the issue. No spec by design (issue explicitly calls this out). Lands as a separate commit so the autoload-style require glob has a stable file to find before T1.3's fakes start using it.

Both modules are auto-included into RSpec example groups via `config.include` in `spec_helper.rb`, so `capture_stdio` and `with_tmp_config` are callable inside any `it` block without an explicit `include`.

## Test plan

All five acceptance gates green:

- [x] `bundle exec rspec spec/support/stdio_capture_spec.rb` — `4 examples, 0 failures`
- [x] `bundle exec rspec spec/support/tmp_config_spec.rb` — `3 examples, 0 failures`
- [x] `ruby -e 'load "spec/support/factories.rb"; puts "ok"'` prints `ok`
- [x] `ruby -Ispec -rspec_helper -e '...'` reports `RSpec auto-includes: WebMock::API, WebMock::Matchers, StdioCapture, TmpConfig`
- [x] `git diff main -- lib/ slack_status.rb` is empty (no domain code touched)

Full suite: `7 examples, 0 failures`.

## Design notes (worth a second pair of eyes)

- **Glob fix in `spec_helper.rb`.** The T1.1 glob (`Dir[...support/**/*.rb]...require`) happily picked up the new `*_spec.rb` files alongside the support modules, registering every spec twice (caught immediately: first green run reported 8 examples for a 4-example file). Added a `.reject { |file| file.end_with?("_spec.rb") }` so the glob is strictly for support files. Caught on the first green run, fixed in the same commit since the spec proves the fix.
- **Anonymous host class in specs.** Both `stdio_capture_spec.rb` and `tmp_config_spec.rb` mint `Class.new { include StdioCapture }.new` (or `TmpConfig`) rather than relying on the spec_helper auto-include. That way the spec is honest about the module's surface — it'd still pass even if someone yanked `config.include …` out of the spec_helper. The auto-include is verified separately in the "spec_helper auto-include" acceptance gate above.
- **`StringIO` over `Tempfile`.** `StdioCapture` uses `StringIO` (in-memory) rather than `Tempfile` so there's nothing to clean up — fits the "silence and capture" contract without touching disk.
- **Keyword-arg block contract for `TmpConfig`.** The issue's pseudocode uses `block.call(path: path, dir: dir)` (kwargs, not positional). Kept that exactly — yielding kwargs makes call-sites self-documenting (`with_tmp_config do |path:, dir:|`) and lets future fields (`config_root:`?) be added non-breakingly.

## Out of scope

- Shared fakes (`FakeShellRunner`, `FakeSleeper`) — T1.3 (#9)
- Any factory helpers — added by downstream tasks as they need them
- Any domain-class extraction — Epics 2-7

Made with [Cursor](https://cursor.com)