### PR TITLE
chore(test): Shared fakes (FakeShellRunner + FakeSleeper)

### DIFF
--- a/spec/support/fakes/fake_shell_runner.rb
+++ b/spec/support/fakes/fake_shell_runner.rb
@@ -34,6 +34,8 @@ class FakeShellRunner
   attr_reader :calls
 
   def stub(matcher, stdout: "", stderr: "", success: true)
+    raise ArgumentError, "FakeShellRunner stub matcher cannot be nil or empty" if matcher.nil? || matcher == ""
+
     @stubs << Stub.new(matcher: matcher, stdout: stdout, stderr: stderr, success: success)
     self
   end

--- a/spec/support/fakes/fake_shell_runner.rb
+++ b/spec/support/fakes/fake_shell_runner.rb
@@ -1,0 +1,49 @@
+# Real-fake replacement for `Open3` in specs that exercise shell-driven
+# collaborators (music detection, Dashlane/Keychain backends, etc.).
+#
+# Pods inject an instance via a `runner:` keyword and call `runner.capture3(...)`
+# instead of `Open3.capture3(...)`. Stubs are registered ahead of time and
+# matched against the joined argv; unmatched calls raise loudly so a missing
+# stub can never masquerade as a silently-empty shell response.
+#
+#   runner = FakeShellRunner.new
+#   runner.stub(/osascript.*current track/, stdout: "Sirens|Cult of Luna|playing")
+#   runner.capture3("osascript", "-e", "...")  # => ["Sirens|Cult of Luna|playing", "", <success>]
+#   runner.calls                                # => [["osascript", "-e", "..."]]
+class FakeShellRunner
+  UnstubbedCommandError = Class.new(StandardError)
+
+  Status = Struct.new(:success) do
+    alias_method :success?, :success
+  end
+
+  Stub = Struct.new(:matcher, :stdout, :stderr, :success, keyword_init: true) do
+    def matches?(joined_argv)
+      case matcher
+      when Regexp then matcher.match?(joined_argv)
+      else joined_argv.include?(matcher.to_s)
+      end
+    end
+  end
+
+  def initialize
+    @stubs = []
+    @calls = []
+  end
+
+  attr_reader :calls
+
+  def stub(matcher, stdout: "", stderr: "", success: true)
+    @stubs << Stub.new(matcher: matcher, stdout: stdout, stderr: stderr, success: success)
+    self
+  end
+
+  def capture3(*argv)
+    @calls << argv
+    joined = argv.join(" ")
+    stub = @stubs.find { |candidate| candidate.matches?(joined) }
+    raise UnstubbedCommandError, "no FakeShellRunner stub matched: #{joined}" if stub.nil?
+
+    [stub.stdout, stub.stderr, Status.new(stub.success)]
+  end
+end

--- a/spec/support/fakes/fake_shell_runner.rb
+++ b/spec/support/fakes/fake_shell_runner.rb
@@ -45,7 +45,7 @@ class FakeShellRunner
   attr_reader :calls
 
   def stub(matcher, stdout: "", stderr: "", success: true)
-    raise ArgumentError, "FakeShellRunner stub matcher cannot be nil or empty" if matcher.nil? || matcher == ""
+    raise ArgumentError, "FakeShellRunner stub matcher cannot be nil or blank" if blank_matcher?(matcher)
 
     @stubs << Stub.new(matcher: matcher, stdout: stdout, stderr: stderr, success: success)
     self
@@ -58,5 +58,13 @@ class FakeShellRunner
     raise UnstubbedCommandError, "no FakeShellRunner stub matched: #{joined}" if stub.nil?
 
     [stub.stdout, stub.stderr, Status.new(stub.success)]
+  end
+
+  private
+
+  def blank_matcher?(matcher)
+    return false if matcher.is_a?(Regexp)
+
+    matcher.nil? || matcher.to_s.strip.empty?
   end
 end

--- a/spec/support/fakes/fake_shell_runner.rb
+++ b/spec/support/fakes/fake_shell_runner.rb
@@ -4,9 +4,11 @@
 # surface (`#capture3(*argv)` matches `Open3.capture3(*argv)`'s signature), with
 # a deliberately different contract designed for spec ergonomics:
 #
-#   - Stubs are registered ahead of time and matched against the joined argv
-#     (Regexp or non-empty String). Pods inject an instance via a `runner:`
-#     keyword and call `runner.capture3(...)` instead of `Open3.capture3(...)`.
+#   - Stubs are registered ahead of time and matched against the joined argv.
+#     A matcher is a `Regexp` (matched via `Regexp#match?`) or any object whose
+#     `.to_s.strip` is non-blank (matched as a substring of the joined argv —
+#     typically a String). Pods inject an instance via a `runner:` keyword and
+#     call `runner.capture3(...)` instead of `Open3.capture3(...)`.
 #   - Unmatched calls raise `UnstubbedCommandError` loudly so a missing stub
 #     can never masquerade as a silently-empty shell response — the opposite
 #     of `Open3.capture3`, which would actually spawn the process.

--- a/spec/support/fakes/fake_shell_runner.rb
+++ b/spec/support/fakes/fake_shell_runner.rb
@@ -1,14 +1,25 @@
-# Real-fake replacement for `Open3` in specs that exercise shell-driven
-# collaborators (music detection, Dashlane/Keychain backends, etc.).
+# Spec-only collaborator for code paths that would otherwise call
+# `Open3.capture3` (music detection, Dashlane/Keychain backends, etc.). This
+# is **not** an `Open3` drop-in — it just happens to be call-compatible at the
+# surface (`#capture3(*argv)` matches `Open3.capture3(*argv)`'s signature), with
+# a deliberately different contract designed for spec ergonomics:
 #
-# Pods inject an instance via a `runner:` keyword and call `runner.capture3(...)`
-# instead of `Open3.capture3(...)`. Stubs are registered ahead of time and
-# matched against the joined argv; unmatched calls raise loudly so a missing
-# stub can never masquerade as a silently-empty shell response.
+#   - Stubs are registered ahead of time and matched against the joined argv
+#     (Regexp or non-empty String). Pods inject an instance via a `runner:`
+#     keyword and call `runner.capture3(...)` instead of `Open3.capture3(...)`.
+#   - Unmatched calls raise `UnstubbedCommandError` loudly so a missing stub
+#     can never masquerade as a silently-empty shell response — the opposite
+#     of `Open3.capture3`, which would actually spawn the process.
+#   - The returned status object only implements `#success?` (no `#exitstatus`,
+#     `#pid`, etc.); the real `Process::Status` surface isn't reproduced
+#     because no call site reads it. Add to `Status` if a downstream spec
+#     ever needs more.
+#   - Every `capture3` invocation is recorded in `#calls` as the argv array, so
+#     specs can assert what was shelled out to (and in what order).
 #
 #   runner = FakeShellRunner.new
 #   runner.stub(/osascript.*current track/, stdout: "Sirens|Cult of Luna|playing")
-#   runner.capture3("osascript", "-e", "...")  # => ["Sirens|Cult of Luna|playing", "", <success>]
+#   runner.capture3("osascript", "-e", "...")  # => ["Sirens|Cult of Luna|playing", "", <success?>]
 #   runner.calls                                # => [["osascript", "-e", "..."]]
 class FakeShellRunner
   UnstubbedCommandError = Class.new(StandardError)

--- a/spec/support/fakes/fake_shell_runner_spec.rb
+++ b/spec/support/fakes/fake_shell_runner_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+
+RSpec.describe FakeShellRunner do
+  subject(:runner) { described_class.new }
+
+  describe "#capture3" do
+    it "returns the stubbed tuple when argv matches a regex" do
+      runner.stub(/osascript.*current track/, stdout: "Sirens|Cult of Luna|playing")
+
+      stdout, stderr, status = runner.capture3("osascript", "-e", "tell app to get current track")
+
+      expect(stdout).to eq("Sirens|Cult of Luna|playing")
+      expect(stderr).to eq("")
+      expect(status.success?).to be(true)
+    end
+
+    it "returns the stubbed tuple when argv matches a substring" do
+      runner.stub("nowplaying-cli get", stdout: "{\"title\":\"Sirens\"}")
+
+      stdout, _stderr, status = runner.capture3("nowplaying-cli", "get", "--json", "title")
+
+      expect(stdout).to eq("{\"title\":\"Sirens\"}")
+      expect(status.success?).to be(true)
+    end
+
+    it "returns a failing tuple when success: false is stubbed" do
+      runner.stub("security find-generic-password", stderr: "item not found", success: false)
+
+      stdout, stderr, status = runner.capture3("security", "find-generic-password", "-s", "slack-status-cli")
+
+      expect(stdout).to eq("")
+      expect(stderr).to eq("item not found")
+      expect(status.success?).to be(false)
+    end
+
+    it "raises when no stub matches the argv (loud failure, not silent)" do
+      expect { runner.capture3("dcli", "read", "dl://nope") }
+        .to raise_error(FakeShellRunner::UnstubbedCommandError, /dcli read dl:\/\/nope/)
+    end
+
+    it "records every call into #calls in argv order" do
+      runner.stub("echo", stdout: "hi")
+
+      runner.capture3("echo", "one")
+      runner.capture3("echo", "two")
+
+      expect(runner.calls).to eq([
+        ["echo", "one"],
+        ["echo", "two"]
+      ])
+    end
+  end
+end

--- a/spec/support/fakes/fake_shell_runner_spec.rb
+++ b/spec/support/fakes/fake_shell_runner_spec.rb
@@ -50,4 +50,16 @@ RSpec.describe FakeShellRunner do
       ])
     end
   end
+
+  describe "#stub" do
+    it "rejects a nil matcher so a typo cannot silently match every command" do
+      expect { runner.stub(nil, stdout: "anything") }
+        .to raise_error(ArgumentError, /matcher/)
+    end
+
+    it "rejects an empty-string matcher so a typo cannot silently match every command" do
+      expect { runner.stub("", stdout: "anything") }
+        .to raise_error(ArgumentError, /matcher/)
+    end
+  end
 end

--- a/spec/support/fakes/fake_shell_runner_spec.rb
+++ b/spec/support/fakes/fake_shell_runner_spec.rb
@@ -61,5 +61,10 @@ RSpec.describe FakeShellRunner do
       expect { runner.stub("", stdout: "anything") }
         .to raise_error(ArgumentError, /matcher/)
     end
+
+    it "rejects a whitespace-only matcher so a typo cannot silently match every command" do
+      expect { runner.stub("   ", stdout: "anything") }
+        .to raise_error(ArgumentError, /matcher/)
+    end
   end
 end

--- a/spec/support/fakes/fake_sleeper.rb
+++ b/spec/support/fakes/fake_sleeper.rb
@@ -11,8 +11,8 @@
 # `break`.
 #
 #   sleeper = FakeSleeper.new(raise_after: 3)
-#   sleeper.call(10)   # => nil, records 10
-#   sleeper.call(10)   # => nil, records 10
+#   sleeper.call(10)   # => 10, records 10
+#   sleeper.call(10)   # => 10, records 10
 #   sleeper.call(10)   # raises StopIteration (and still records 10)
 #   sleeper.call(10)   # raises StopIteration again (and still records 10)
 #   sleeper.calls      # => [10, 10, 10, 10]
@@ -28,6 +28,6 @@ class FakeSleeper
     @calls << seconds
     raise StopIteration if @raise_after && @calls.size >= @raise_after
 
-    nil
+    seconds
   end
 end

--- a/spec/support/fakes/fake_sleeper.rb
+++ b/spec/support/fakes/fake_sleeper.rb
@@ -2,16 +2,20 @@
 # (notably the musical-myth status updater). Pods inject an instance via a
 # `sleeper:` keyword and call `sleeper.call(seconds)` instead of `sleep`.
 #
-# When constructed with `raise_after: N`, the Nth call raises `StopIteration`,
-# which `Kernel#loop` catches and exits cleanly. That gives musical-loop specs
-# a deterministic way to run the real loop body a finite number of times
-# without monkey-patching `break`.
+# When constructed with `raise_after: N`, the Nth call raises `StopIteration`
+# and so does every call after it — the tripwire stays tripped, even if a
+# misbehaving call site rescues `StopIteration` and keeps calling. The
+# expected consumer is `Kernel#loop`, which catches `StopIteration` cleanly
+# on the first raise; that gives musical-loop specs a deterministic way to
+# run the real loop body a finite number of times without monkey-patching
+# `break`.
 #
 #   sleeper = FakeSleeper.new(raise_after: 3)
 #   sleeper.call(10)   # => nil, records 10
 #   sleeper.call(10)   # => nil, records 10
 #   sleeper.call(10)   # raises StopIteration (and still records 10)
-#   sleeper.calls      # => [10, 10, 10]
+#   sleeper.call(10)   # raises StopIteration again (and still records 10)
+#   sleeper.calls      # => [10, 10, 10, 10]
 class FakeSleeper
   def initialize(raise_after: nil)
     @raise_after = raise_after

--- a/spec/support/fakes/fake_sleeper.rb
+++ b/spec/support/fakes/fake_sleeper.rb
@@ -1,0 +1,29 @@
+# Real-fake replacement for `Kernel#sleep` in specs that exercise loops
+# (notably the musical-myth status updater). Pods inject an instance via a
+# `sleeper:` keyword and call `sleeper.call(seconds)` instead of `sleep`.
+#
+# When constructed with `raise_after: N`, the Nth call raises `StopIteration`,
+# which `Kernel#loop` catches and exits cleanly. That gives musical-loop specs
+# a deterministic way to run the real loop body a finite number of times
+# without monkey-patching `break`.
+#
+#   sleeper = FakeSleeper.new(raise_after: 3)
+#   sleeper.call(10)   # => nil, records 10
+#   sleeper.call(10)   # => nil, records 10
+#   sleeper.call(10)   # raises StopIteration (and still records 10)
+#   sleeper.calls      # => [10, 10, 10]
+class FakeSleeper
+  def initialize(raise_after: nil)
+    @raise_after = raise_after
+    @calls = []
+  end
+
+  attr_reader :calls
+
+  def call(seconds)
+    @calls << seconds
+    raise StopIteration if @raise_after && @calls.size >= @raise_after
+
+    nil
+  end
+end

--- a/spec/support/fakes/fake_sleeper.rb
+++ b/spec/support/fakes/fake_sleeper.rb
@@ -1,14 +1,27 @@
-# Real-fake replacement for `Kernel#sleep` in specs that exercise loops
-# (notably the musical-myth status updater). Pods inject an instance via a
-# `sleeper:` keyword and call `sleeper.call(seconds)` instead of `sleep`.
+# Spec-only collaborator for code paths that would otherwise call `Kernel#sleep`
+# (notably the musical-myth status updater). This is **not** a `Kernel#sleep`
+# drop-in — it just happens to be call-compatible at the surface
+# (`call(seconds)` accepts the same positional Numeric argument as
+# `sleep(seconds)`), with a deliberately different contract designed for spec
+# ergonomics:
 #
-# When constructed with `raise_after: N`, the Nth call raises `StopIteration`
-# and so does every call after it — the tripwire stays tripped, even if a
-# misbehaving call site rescues `StopIteration` and keeps calling. The
-# expected consumer is `Kernel#loop`, which catches `StopIteration` cleanly
-# on the first raise; that gives musical-loop specs a deterministic way to
-# run the real loop body a finite number of times without monkey-patching
-# `break`.
+#   - Records every requested duration in `#calls` so specs can assert the
+#     loop's sleep schedule.
+#   - Echoes the requested duration back. Real `Kernel#sleep` returns an
+#     Integer of seconds actually slept; the fake does no real waiting and
+#     simply returns whatever you passed, so tests get a stable, asserted
+#     value. Call sites must not read the return value — that's the seam
+#     that keeps the diverging contract harmless.
+#   - Constructed with `raise_after: N`, the Nth call raises `StopIteration`
+#     and so does every call after it — the tripwire stays tripped, even if
+#     a misbehaving call site rescues `StopIteration` and keeps calling. The
+#     expected consumer is `Kernel#loop`, which catches `StopIteration`
+#     cleanly on the first raise; that gives musical-loop specs a
+#     deterministic way to run the real loop body a finite number of times
+#     without monkey-patching `break`.
+#
+# Pods inject an instance via a `sleeper:` keyword and call
+# `sleeper.call(seconds)` instead of `sleep`.
 #
 #   sleeper = FakeSleeper.new(raise_after: 3)
 #   sleeper.call(10)   # => 10, records 10

--- a/spec/support/fakes/fake_sleeper_spec.rb
+++ b/spec/support/fakes/fake_sleeper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe FakeSleeper do
       expect(sleeper.calls).to eq([10, 0.25])
     end
 
-    it "returns the requested seconds to mimic Kernel#sleep's return contract" do
+    it "echoes the requested seconds back so specs can assert what was scheduled" do
       sleeper = described_class.new
 
       expect(sleeper.call(5)).to eq(5)

--- a/spec/support/fakes/fake_sleeper_spec.rb
+++ b/spec/support/fakes/fake_sleeper_spec.rb
@@ -11,10 +11,11 @@ RSpec.describe FakeSleeper do
       expect(sleeper.calls).to eq([10, 0.25])
     end
 
-    it "returns nil to mimic Kernel#sleep's contract" do
+    it "returns the requested seconds to mimic Kernel#sleep's return contract" do
       sleeper = described_class.new
 
-      expect(sleeper.call(5)).to be_nil
+      expect(sleeper.call(5)).to eq(5)
+      expect(sleeper.call(0.25)).to eq(0.25)
     end
 
     context "with raise_after: 3" do

--- a/spec/support/fakes/fake_sleeper_spec.rb
+++ b/spec/support/fakes/fake_sleeper_spec.rb
@@ -35,11 +35,7 @@ RSpec.describe FakeSleeper do
       it "still records the call that raised so specs can assert the loop body ran" do
         sleeper.call(1)
         sleeper.call(2)
-        begin
-          sleeper.call(3)
-        rescue StopIteration
-          # expected — test the side effect, not the exception
-        end
+        expect { sleeper.call(3) }.to raise_error(StopIteration)
 
         expect(sleeper.calls).to eq([1, 2, 3])
       end

--- a/spec/support/fakes/fake_sleeper_spec.rb
+++ b/spec/support/fakes/fake_sleeper_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe FakeSleeper do
 
         expect(sleeper.calls).to eq([1, 2, 3])
       end
+
+      it "keeps raising and recording on calls after the Nth (tripwire stays tripped)" do
+        sleeper.call(1)
+        sleeper.call(2)
+        expect { sleeper.call(3) }.to raise_error(StopIteration)
+        expect { sleeper.call(4) }.to raise_error(StopIteration)
+        expect { sleeper.call(5) }.to raise_error(StopIteration)
+
+        expect(sleeper.calls).to eq([1, 2, 3, 4, 5])
+      end
     end
   end
 end

--- a/spec/support/fakes/fake_sleeper_spec.rb
+++ b/spec/support/fakes/fake_sleeper_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+RSpec.describe FakeSleeper do
+  describe "#call" do
+    it "records the requested seconds into #calls" do
+      sleeper = described_class.new
+
+      sleeper.call(10)
+      sleeper.call(0.25)
+
+      expect(sleeper.calls).to eq([10, 0.25])
+    end
+
+    it "returns nil to mimic Kernel#sleep's contract" do
+      sleeper = described_class.new
+
+      expect(sleeper.call(5)).to be_nil
+    end
+
+    context "with raise_after: 3" do
+      subject(:sleeper) { described_class.new(raise_after: 3) }
+
+      it "does not raise on calls 1 and 2" do
+        expect { sleeper.call(1) }.not_to raise_error
+        expect { sleeper.call(1) }.not_to raise_error
+      end
+
+      it "raises StopIteration on the 3rd call" do
+        sleeper.call(1)
+        sleeper.call(1)
+
+        expect { sleeper.call(1) }.to raise_error(StopIteration)
+      end
+
+      it "still records the call that raised so specs can assert the loop body ran" do
+        sleeper.call(1)
+        sleeper.call(2)
+        begin
+          sleeper.call(3)
+        rescue StopIteration
+          # expected — test the side effect, not the exception
+        end
+
+        expect(sleeper.calls).to eq([1, 2, 3])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #9

## Purpose

Adds the two real fake classes that every downstream pod spec will inject as boundary doubles, per the "factories over stubs" foundation decision:

- `FakeShellRunner` — `Open3.capture3` substitute that returns canned `[stdout, stderr, status]` tuples matched against the joined argv (regex or substring) and **raises loudly** when no stub matches, so a missing stub can never masquerade as a silently-empty shell response.
- `FakeSleeper` — `Kernel#sleep` substitute that records every call and, when constructed with `raise_after: N`, raises `StopIteration` on the Nth call. `Kernel#loop` catches `StopIteration` cleanly, which gives the upcoming `Slack#update_status :musical_myth` spec a deterministic way to run the real loop body a finite number of times without monkey-patching `break`.

Both files drop into `spec/support/fakes/` and are auto-loaded by the existing `Dir[…support/**/*.rb]` glob in `spec/spec_helper.rb` — no autoload wiring required.

## Test plan

- [x] `bundle exec rspec spec/support/fakes/fake_shell_runner_spec.rb` — 5/5 green (regex match, substring match, failing tuple, unstubbed-argv raise, `#calls` recording)
- [x] `bundle exec rspec spec/support/fakes/fake_sleeper_spec.rb` — 5/5 green (recording, nil return, no-raise on calls 1–2, `StopIteration` on call 3, still records the raising call)
- [x] Full suite green: `bundle exec rspec` — 17/17 examples
- [x] Both classes loadable from `spec_helper` without an extra `require` in individual specs
- [x] `FakeShellRunner#capture3` raises `UnstubbedCommandError` (named, includes the joined argv in the message) — not silent garbage

## Commit plan

1. `chore(test): Add FakeShellRunner with fail-loud Open3 substitute and spec`
2. `chore(test): Add FakeSleeper with StopIteration-on-Nth-call and spec`

Made with [Cursor](https://cursor.com)