### PR TITLE
feat(scrubber): Extract shared SecretScrubber and delegate CliPrompt

### DIFF
--- a/lib/cli_prompt.rb
+++ b/lib/cli_prompt.rb
@@ -1,4 +1,5 @@
 require 'io/console'
+require 'slack_status_cli'
 
 # Standard interactive UX helpers shared by every CLI prompt in this tool.
 # Centralizing them keeps `[Y/n]` semantics, secret-input echo-off, and the
@@ -139,11 +140,10 @@ module CliPrompt
 
   # Scrubs Slack token shapes (xoxp-, xoxb-, xoxc-, xoxd-, xoxa-, xoxs-, xoxr-)
   # from any string so caught exceptions or response bodies don't accidentally
-  # log the secret.
-  SECRET_PATTERN = /\bxox[a-z]-[A-Za-z0-9-]+/
+  # log the secret. Thin delegation to the shared Callable so every pod sees
+  # an identical redaction shape.
   def scrub_secrets(text)
-    return text if text.nil?
-    text.to_s.gsub(SECRET_PATTERN) { |m| "xox?-#{redacted(m, keep: 4)}" }
+    SlackStatusCli::SecretScrubber.call(text: text)
   end
 
   def emoji(key)

--- a/lib/slack.rb
+++ b/lib/slack.rb
@@ -2,6 +2,7 @@ require 'music'
 require 'net/http'
 require 'json'
 require 'uri'
+require 'slack_status_cli'
 
 class Slack
   MYTH_MOJIS = [":wolf:", ":lion_face:", ":phoenix_ash:", ":fox_face:", ":butterfly:"]
@@ -252,14 +253,7 @@ class Slack
   end
 
   def body_excerpt(body, limit: 200)
-    snippet = scrub(body.strip)
+    snippet = SlackStatusCli::SecretScrubber.call(text: body.strip)
     snippet.length > limit ? "#{snippet[0, limit]}…" : snippet
-  end
-
-  # Defense-in-depth: even though Slack's responses don't echo the token,
-  # scrub any `xox?-` pattern before printing so a future log statement
-  # can't accidentally leak a secret.
-  def scrub(text)
-    text.to_s.gsub(/\bxox[a-z]-[A-Za-z0-9-]+/) { |m| "xox?-…#{m[-4, 4]}" }
   end
 end

--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -5,4 +5,5 @@
 # used by both `slack_status.rb` (the CLI dispatcher) and the spec_helper.
 module SlackStatusCli
   autoload :Callable, "slack_status_cli/callable"
+  autoload :SecretScrubber, "slack_status_cli/secret_scrubber"
 end

--- a/lib/slack_status_cli/secret_scrubber.rb
+++ b/lib/slack_status_cli/secret_scrubber.rb
@@ -1,0 +1,24 @@
+module SlackStatusCli
+  # Defense-in-depth: replaces any Slack-shaped token (xoxp-, xoxb-, xoxa-,
+  # xoxc-, xoxd-, xoxs-, xoxr-) inside an arbitrary string with
+  # "xox?-…LAST4" so log lines, exception messages, and response snippets
+  # can't accidentally leak a live secret. Idempotent and safe on nil.
+  class SecretScrubber
+    extend Callable
+
+    SECRET_PATTERN = /\bxox[a-z]-[A-Za-z0-9-]+/
+
+    def initialize(text:)
+      @text = text
+    end
+
+    def call
+      return nil if text.nil?
+      text.to_s.gsub(SECRET_PATTERN) { |match| "xox?-…#{match[-4, 4]}" }
+    end
+
+    private
+
+    attr_reader :text
+  end
+end

--- a/spec/cli_prompt_spec.rb
+++ b/spec/cli_prompt_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+require "cli_prompt"
+
+RSpec.describe CliPrompt do
+  describe ".scrub_secrets" do
+    it "redacts an xoxp-* token to the same xox?-…LAST4 shape SecretScrubber uses" do
+      result = described_class.scrub_secrets("token=xoxp-abcd1234efgh tail")
+
+      expect(result).to eq("token=xox?-…efgh tail")
+    end
+
+    it "redacts an xoxb-* token" do
+      expect(described_class.scrub_secrets("bot=xoxb-0987zyxw")).to eq("bot=xox?-…zyxw")
+    end
+
+    it "redacts every match when multiple tokens appear in the same string" do
+      result = described_class.scrub_secrets("a=xoxp-firsttok1111 b=xoxb-secondtok2222")
+
+      expect(result).to eq("a=xox?-…1111 b=xox?-…2222")
+    end
+
+    it "leaves non-token text unchanged" do
+      expect(described_class.scrub_secrets("nothing sensitive, xox in prose stays put"))
+        .to eq("nothing sensitive, xox in prose stays put")
+    end
+
+    it "returns nil when given nil" do
+      expect(described_class.scrub_secrets(nil)).to be_nil
+    end
+
+    it "is idempotent: scrubbing scrubbed text is a no-op" do
+      once = described_class.scrub_secrets("token=xoxp-abcd1234efgh tail")
+      twice = described_class.scrub_secrets(once)
+
+      expect(twice).to eq(once)
+    end
+  end
+end

--- a/spec/slack_status_cli/secret_scrubber_spec.rb
+++ b/spec/slack_status_cli/secret_scrubber_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::SecretScrubber do
+  describe ".call" do
+    it "redacts an xoxp-* user token, keeping only the last 4 characters" do
+      result = described_class.call(text: "token=xoxp-abcd1234efgh and the rest")
+
+      expect(result).to eq("token=xox?-…efgh and the rest")
+    end
+
+    it "redacts an xoxb-* bot token" do
+      result = described_class.call(text: "bot=xoxb-0987zyxw")
+
+      expect(result).to eq("bot=xox?-…zyxw")
+    end
+
+    it "redacts an xoxa-* app token" do
+      result = described_class.call(text: "app xoxa-2222aaaa3333 leak")
+
+      expect(result).to eq("app xox?-…3333 leak")
+    end
+
+    it "redacts every match when multiple tokens appear in the same string" do
+      result = described_class.call(text: "a=xoxp-firsttok1111 b=xoxb-secondtok2222")
+
+      expect(result).to eq("a=xox?-…1111 b=xox?-…2222")
+    end
+
+    it "leaves non-token text unchanged" do
+      result = described_class.call(text: "nothing sensitive here, xox in prose stays put")
+
+      expect(result).to eq("nothing sensitive here, xox in prose stays put")
+    end
+
+    it "returns nil when given nil so callers can scrub optional fields safely" do
+      expect(described_class.call(text: nil)).to be_nil
+    end
+
+    it "is idempotent: scrubbing already-scrubbed text is a no-op" do
+      once = described_class.call(text: "token=xoxp-abcd1234efgh tail")
+      twice = described_class.call(text: once)
+
+      expect(twice).to eq(once)
+    end
+  end
+end


### PR DESCRIPTION
Closes #17

## Purpose

Extracts the duplicated Slack-token redaction logic out of `Slack#scrub` and `CliPrompt.scrub_secrets` into a single shared `SlackStatusCli::SecretScrubber` Callable, so every pod sees an identical `xox?-…LAST4` redaction shape. First task in Epic 2 (#10) — a small, dependency-free lead-in that future Slack-pod Callables (e.g. `Formatters::ResponseLogger` in T2.2) will also delegate to.

## Test plan

- [x] `bundle exec rspec spec/slack_status_cli/secret_scrubber_spec.rb` green (7 examples covering xoxp/xoxb/xoxa redaction, multi-match, nil safety, idempotency, non-token passthrough).
- [x] `bundle exec rspec spec/cli_prompt_spec.rb` green (6 characterization specs — pinned the existing CliPrompt output **before** the delegation refactor so behaviour drift would have failed loudly).
- [x] Full suite still 34/34 green.
- [x] `Slack#body_excerpt` now delegates to `SecretScrubber`; `Slack#scrub` removed.

## Commit plan

1. `feat(scrubber): Extract SecretScrubber Callable from Slack#scrub`
2. `refactor(cli-prompt): Delegate CliPrompt.scrub_secrets to SecretScrubber`

Made with [Cursor](https://cursor.com)