### PR TITLE
T2.3 — Slack builders (ExpirationSeconds + ModeStatus + StatusPayload)

### DIFF
--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -18,6 +18,7 @@ module SlackStatusCli
 
     module Builders
       autoload :ExpirationSeconds, "slack_status_cli/slack/builders/expiration_seconds"
+      autoload :ModeStatus, "slack_status_cli/slack/builders/mode_status"
     end
   end
 end

--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -19,6 +19,7 @@ module SlackStatusCli
     module Builders
       autoload :ExpirationSeconds, "slack_status_cli/slack/builders/expiration_seconds"
       autoload :ModeStatus, "slack_status_cli/slack/builders/mode_status"
+      autoload :StatusPayload, "slack_status_cli/slack/builders/status_payload"
     end
   end
 end

--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -15,5 +15,9 @@ module SlackStatusCli
       autoload :StateLabel, "slack_status_cli/slack/formatters/state_label"
       autoload :ResponseLogger, "slack_status_cli/slack/formatters/response_logger"
     end
+
+    module Builders
+      autoload :ExpirationSeconds, "slack_status_cli/slack/builders/expiration_seconds"
+    end
   end
 end

--- a/lib/slack_status_cli/slack/builders/expiration_seconds.rb
+++ b/lib/slack_status_cli/slack/builders/expiration_seconds.rb
@@ -1,0 +1,45 @@
+module SlackStatusCli
+  module Slack
+    module Builders
+      # Coerces a status-expiration input into an absolute epoch-seconds Integer
+      # (or nil when there is nothing to set). Accepts:
+      #   - a plain integer / integer string -> treated as an absolute epoch
+      #   - a relative duration like "30m" / "2h" -> now + offset
+      #   - nil / blank / unrecognized input -> nil
+      class ExpirationSeconds
+        extend Callable
+
+        UNIT_SECONDS = { "m" => 60, "h" => 60 * 60 }.freeze
+        RELATIVE = /\A(\d+)([mh])\z/.freeze
+        ABSOLUTE = /\A\d+\z/.freeze
+
+        def initialize(value:, now: Time.now)
+          @value = value
+          @now = now
+        end
+
+        def call
+          return if blank?
+
+          if (match = RELATIVE.match(token))
+            now.to_i + (match[1].to_i * UNIT_SECONDS.fetch(match[2]))
+          elsif ABSOLUTE.match?(token)
+            token.to_i
+          end
+        end
+
+        private
+
+        attr_reader :value, :now
+
+        def token
+          @token ||= value.to_s.strip
+        end
+
+        def blank?
+          value.nil? || token.empty?
+        end
+      end
+    end
+  end
+end

--- a/lib/slack_status_cli/slack/builders/mode_status.rb
+++ b/lib/slack_status_cli/slack/builders/mode_status.rb
@@ -1,0 +1,41 @@
+module SlackStatusCli
+  module Slack
+    module Builders
+      # Maps a mode symbol to the status triple Slack expects: text, emoji, and
+      # an optional absolute-epoch expiration. Time-bound modes (lunch/break)
+      # compute their expiration from the injected `now:` so specs stay
+      # deterministic. Unknown modes raise rather than silently returning nil.
+      class ModeStatus
+        extend Callable
+
+        MYTH_MOJIS = [":wolf:", ":lion_face:", ":phoenix_ash:", ":fox_face:", ":butterfly:"].freeze
+        LUNCH_SECONDS = 3600
+        BREAK_SECONDS = 1800
+
+        def initialize(mode:, now: Time.now)
+          @mode = mode
+          @now = now
+        end
+
+        def call
+          case mode
+          when :myth
+            { text: "", emoji: MYTH_MOJIS.sample, expiration: nil }
+          when :musical_myth
+            { text: "", emoji: ":music:", expiration: nil }
+          when :lunch
+            { text: "#{MYTH_MOJIS.sample} - Lunch time!", emoji: ":meat_on_bone:", expiration: now.to_i + LUNCH_SECONDS }
+          when :break
+            { text: "#{MYTH_MOJIS.sample} Taking a break", emoji: ":coffee:", expiration: now.to_i + BREAK_SECONDS }
+          else
+            raise ArgumentError, "Unknown mode: #{mode.inspect}"
+          end
+        end
+
+        private
+
+        attr_reader :mode, :now
+      end
+    end
+  end
+end

--- a/lib/slack_status_cli/slack/builders/status_payload.rb
+++ b/lib/slack_status_cli/slack/builders/status_payload.rb
@@ -1,0 +1,40 @@
+require "json"
+
+module SlackStatusCli
+  module Slack
+    module Builders
+      # Builds the JSON body for Slack's users.profile.set. Composes
+      # ExpirationSeconds so callers can pass a raw expiration input ("30m",
+      # an epoch string, or nil); a nil resolution becomes 0, which Slack
+      # interprets as "no expiration".
+      class StatusPayload
+        extend Callable
+
+        def initialize(text:, emoji:, expiration:, now: Time.now)
+          @text = text
+          @emoji = emoji
+          @expiration = expiration
+          @now = now
+        end
+
+        def call
+          {
+            profile: {
+              status_text: text,
+              status_emoji: emoji,
+              status_expiration: resolved_expiration
+            }
+          }.to_json
+        end
+
+        private
+
+        attr_reader :text, :emoji, :expiration, :now
+
+        def resolved_expiration
+          ExpirationSeconds.call(value: expiration, now: now) || 0
+        end
+      end
+    end
+  end
+end

--- a/spec/slack_status_cli/slack/builders/expiration_seconds_spec.rb
+++ b/spec/slack_status_cli/slack/builders/expiration_seconds_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Slack::Builders::ExpirationSeconds do
+  describe ".call" do
+    let(:now) { Time.at(1_700_000_000) }
+
+    context "with a plain integer string" do
+      it "returns the integer parsed as an absolute epoch" do
+        expect(described_class.call(value: "1700000000", now: now)).to eq(1_700_000_000)
+      end
+    end
+
+    context "with an integer value" do
+      it "returns the integer as an absolute epoch" do
+        expect(described_class.call(value: 1_700_000_000, now: now)).to eq(1_700_000_000)
+      end
+    end
+
+    context "with a '30m' relative duration" do
+      it "returns now + 30 * 60" do
+        expect(described_class.call(value: "30m", now: now)).to eq(now.to_i + (30 * 60))
+      end
+    end
+
+    context "with a '2h' relative duration" do
+      it "returns now + 2 * 60 * 60" do
+        expect(described_class.call(value: "2h", now: now)).to eq(now.to_i + (2 * 60 * 60))
+      end
+    end
+
+    context "with nil" do
+      it "returns nil" do
+        expect(described_class.call(value: nil, now: now)).to be_nil
+      end
+    end
+
+    context "with a blank string" do
+      it "returns nil" do
+        expect(described_class.call(value: "   ", now: now)).to be_nil
+      end
+    end
+
+    context "with garbage" do
+      it "returns nil (matches the old #evaluate_expiration behavior)" do
+        expect(described_class.call(value: "not-a-duration", now: now)).to be_nil
+      end
+    end
+
+    it "defaults now: to Time.now for relative durations" do
+      result = described_class.call(value: "1m")
+
+      expect(result).to be_within(2).of(Time.now.to_i + 60)
+    end
+  end
+end

--- a/spec/slack_status_cli/slack/builders/mode_status_spec.rb
+++ b/spec/slack_status_cli/slack/builders/mode_status_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Slack::Builders::ModeStatus do
+  describe ".call" do
+    let(:now) { Time.at(1_700_000_000) }
+
+    context "with :myth" do
+      it "returns an empty text, a mythical emoji, and no expiration" do
+        result = described_class.call(mode: :myth, now: now)
+
+        expect(result[:text]).to eq("")
+        expect(described_class::MYTH_MOJIS).to include(result[:emoji])
+        expect(result[:expiration]).to be_nil
+      end
+    end
+
+    context "with :musical_myth" do
+      it "returns the music emoji, an empty text, and no expiration" do
+        result = described_class.call(mode: :musical_myth, now: now)
+
+        expect(result).to include(text: "", emoji: ":music:", expiration: nil)
+      end
+    end
+
+    context "with :lunch" do
+      it "returns the lunch emoji and an expiration one hour from now:" do
+        result = described_class.call(mode: :lunch, now: now)
+
+        expect(result[:emoji]).to eq(":meat_on_bone:")
+        expect(result[:text]).to match(/Lunch time!/)
+        expect(result[:expiration]).to eq(now.to_i + 3600)
+      end
+    end
+
+    context "with :break" do
+      it "returns the coffee emoji and an expiration thirty minutes from now:" do
+        result = described_class.call(mode: :break, now: now)
+
+        expect(result[:emoji]).to eq(":coffee:")
+        expect(result[:text]).to match(/Taking a break/)
+        expect(result[:expiration]).to eq(now.to_i + 1800)
+      end
+    end
+
+    context "with an unknown mode" do
+      it "raises a clear ArgumentError naming the mode" do
+        expect { described_class.call(mode: :nonsense, now: now) }
+          .to raise_error(ArgumentError, /nonsense/)
+      end
+    end
+
+    it "uses the injected now: when computing time-bound expirations" do
+      later = Time.at(1_800_000_000)
+
+      expect(described_class.call(mode: :lunch, now: later)[:expiration]).to eq(later.to_i + 3600)
+    end
+  end
+end

--- a/spec/slack_status_cli/slack/builders/status_payload_spec.rb
+++ b/spec/slack_status_cli/slack/builders/status_payload_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+require "json"
+
+RSpec.describe SlackStatusCli::Slack::Builders::StatusPayload do
+  describe ".call" do
+    let(:now) { Time.at(1_700_000_000) }
+
+    def profile(json)
+      JSON.parse(json).fetch("profile")
+    end
+
+    it "returns a JSON string with the profile status keys" do
+      json = described_class.call(text: "heads down", emoji: ":wolf:", expiration: nil)
+
+      expect(profile(json)).to include(
+        "status_text" => "heads down",
+        "status_emoji" => ":wolf:"
+      )
+    end
+
+    it "passes a nil expiration through as 0" do
+      json = described_class.call(text: "", emoji: "", expiration: nil)
+
+      expect(profile(json)["status_expiration"]).to eq(0)
+    end
+
+    it "expands a relative expiration via ExpirationSeconds" do
+      json = described_class.call(text: "lunch", emoji: ":meat_on_bone:", expiration: "30m", now: now)
+
+      expect(profile(json)["status_expiration"]).to eq(now.to_i + (30 * 60))
+    end
+
+    it "passes an absolute epoch expiration through unchanged" do
+      json = described_class.call(text: "", emoji: "", expiration: "1700000000", now: now)
+
+      expect(profile(json)["status_expiration"]).to eq(1_700_000_000)
+    end
+  end
+end


### PR DESCRIPTION
Closes #19

## Purpose
Extracts the three Slack payload Builders from the `lib/slack.rb` god class into pure `Callable`s under `SlackStatusCli::Slack::Builders`. These shape the data `users.profile.set` expects: relative/absolute expirations, mode → status triples, and the final JSON body. `lib/slack.rb` is left untouched (old methods still forwarded internally; deletion lands in T2.6).

## Test plan
- [ ] `bundle exec rspec spec/slack_status_cli/slack/builders/` green (18 examples)
- [ ] `ExpirationSeconds` — absolute epoch passthrough, `30m`/`2h` relative durations, nil/blank/garbage → nil
- [ ] `ModeStatus` — myth/lunch/break/musical_myth triples with injected `now:`; raises on unknown mode
- [ ] `StatusPayload` — JSON keys, composes `ExpirationSeconds`, nil expiration → 0
- [ ] Full suite green (92 examples)

## Commit plan
1. feat(slack-builders): Add ExpirationSeconds Callable + spec
2. feat(slack-builders): Add ModeStatus Callable + spec
3. feat(slack-builders): Add StatusPayload Callable + spec (composes ExpirationSeconds)

Made with [Cursor](https://cursor.com)