### PR TITLE
T2.4 — Slack HTTP (GetRequest + PostRequest)

### DIFF
--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -24,6 +24,7 @@ module SlackStatusCli
 
     module Http
       autoload :GetRequest, "slack_status_cli/slack/http/get_request"
+      autoload :PostRequest, "slack_status_cli/slack/http/post_request"
     end
   end
 end

--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -21,5 +21,9 @@ module SlackStatusCli
       autoload :ModeStatus, "slack_status_cli/slack/builders/mode_status"
       autoload :StatusPayload, "slack_status_cli/slack/builders/status_payload"
     end
+
+    module Http
+      autoload :GetRequest, "slack_status_cli/slack/http/get_request"
+    end
   end
 end

--- a/lib/slack_status_cli/slack/http/get_request.rb
+++ b/lib/slack_status_cli/slack/http/get_request.rb
@@ -13,6 +13,7 @@ module SlackStatusCli
         extend Callable
 
         BASE_URL = "https://slack.com/api/".freeze
+        ABSOLUTE_PATH = %r{\A(?:[a-z][a-z0-9+.-]*:)?//|\A/}i.freeze
 
         def initialize(token:, path:)
           @token = token
@@ -35,8 +36,16 @@ module SlackStatusCli
 
         attr_reader :token, :path
 
+        # Append the API method to the fixed base by string concatenation so a
+        # caller-supplied `path` can never replace the host and leak the bearer
+        # token elsewhere. Absolute or scheme-relative paths are a programming
+        # error, so we raise loudly rather than silently rewriting intent.
         def uri
-          URI.join(BASE_URL, path)
+          if ABSOLUTE_PATH.match?(path.to_s)
+            raise ArgumentError, "path must be a relative Slack API method, got: #{path.inspect}"
+          end
+
+          URI("#{BASE_URL}#{path}")
         end
 
         def request

--- a/lib/slack_status_cli/slack/http/get_request.rb
+++ b/lib/slack_status_cli/slack/http/get_request.rb
@@ -1,0 +1,50 @@
+require "net/http"
+require "json"
+require "uri"
+
+module SlackStatusCli
+  module Slack
+    module Http
+      # Wraps a GET against the Slack Web API. Slack documents auth.test and
+      # emoji.list as GET-friendly (no body required). Returns parsed JSON on a
+      # 2xx response, raises on any non-2xx; transport-level errors propagate
+      # unchanged so callers can distinguish "Slack said no" from "network down".
+      class GetRequest
+        extend Callable
+
+        BASE_URL = "https://slack.com/api/".freeze
+
+        def initialize(token:, path:)
+          @token = token
+          @path = path
+        end
+
+        def call
+          response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+            http.request(request)
+          end
+
+          unless response.is_a?(Net::HTTPSuccess)
+            raise "Slack HTTP #{response.code} #{response.message}"
+          end
+
+          JSON.parse(response.body)
+        end
+
+        private
+
+        attr_reader :token, :path
+
+        def uri
+          URI.join(BASE_URL, path)
+        end
+
+        def request
+          Net::HTTP::Get.new(uri).tap do |req|
+            req["Authorization"] = "Bearer #{token}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/slack_status_cli/slack/http/get_request.rb
+++ b/lib/slack_status_cli/slack/http/get_request.rb
@@ -20,8 +20,8 @@ module SlackStatusCli
         end
 
         def call
-          response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
-            http.request(request)
+          response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |https|
+            https.request(request)
           end
 
           unless response.is_a?(Net::HTTPSuccess)

--- a/lib/slack_status_cli/slack/http/post_request.rb
+++ b/lib/slack_status_cli/slack/http/post_request.rb
@@ -13,6 +13,7 @@ module SlackStatusCli
 
         BASE_URL = "https://slack.com/api/".freeze
         CONTENT_TYPE = "application/json; charset=utf-8".freeze
+        ABSOLUTE_PATH = %r{\A(?:[a-z][a-z0-9+.-]*:)?//|\A/}i.freeze
 
         def initialize(token:, path:, body:)
           @token = token
@@ -30,8 +31,16 @@ module SlackStatusCli
 
         attr_reader :token, :path, :body
 
+        # Append the API method to the fixed base by string concatenation so a
+        # caller-supplied `path` can never replace the host and leak the bearer
+        # token and request body elsewhere. Absolute or scheme-relative paths
+        # are a programming error, so we raise loudly rather than rewrite intent.
         def uri
-          URI.join(BASE_URL, path)
+          if ABSOLUTE_PATH.match?(path.to_s)
+            raise ArgumentError, "path must be a relative Slack API method, got: #{path.inspect}"
+          end
+
+          URI("#{BASE_URL}#{path}")
         end
 
         def request

--- a/lib/slack_status_cli/slack/http/post_request.rb
+++ b/lib/slack_status_cli/slack/http/post_request.rb
@@ -1,0 +1,47 @@
+require "net/http"
+require "uri"
+
+module SlackStatusCli
+  module Slack
+    module Http
+      # Wraps a POST against the Slack Web API with the bearer auth header and a
+      # JSON content type. Returns the raw Net::HTTPResponse rather than parsing
+      # it: the caller (ResponseLogger) decides how to surface ok/non-ok and is
+      # responsible for handling non-2xx, so this Callable never raises on them.
+      class PostRequest
+        extend Callable
+
+        BASE_URL = "https://slack.com/api/".freeze
+        CONTENT_TYPE = "application/json; charset=utf-8".freeze
+
+        def initialize(token:, path:, body:)
+          @token = token
+          @path = path
+          @body = body
+        end
+
+        def call
+          Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |https|
+            https.request(request)
+          end
+        end
+
+        private
+
+        attr_reader :token, :path, :body
+
+        def uri
+          URI.join(BASE_URL, path)
+        end
+
+        def request
+          Net::HTTP::Post.new(uri).tap do |req|
+            req["Authorization"] = "Bearer #{token}"
+            req["Content-Type"] = CONTENT_TYPE
+            req.body = body
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/slack_status_cli/slack/http/get_request_spec.rb
+++ b/spec/slack_status_cli/slack/http/get_request_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Slack::Http::GetRequest do
+  describe ".call" do
+    let(:token) { "xoxp-test-token-1234" }
+
+    it "GETs https://slack.com/api/<path> with bearer auth" do
+      stub = stub_request(:get, "https://slack.com/api/auth.test")
+        .with(headers: { "Authorization" => "Bearer #{token}" })
+        .to_return(status: 200, body: '{"ok":true}')
+
+      described_class.call(token: token, path: "auth.test")
+
+      expect(stub).to have_been_requested
+    end
+
+    it "returns parsed JSON for a 200 response" do
+      stub_request(:get, "https://slack.com/api/emoji.list")
+        .to_return(status: 200, body: '{"ok":true,"emoji":{"foo":"https://x/y.png"}}')
+
+      result = described_class.call(token: token, path: "emoji.list")
+
+      expect(result).to eq("ok" => true, "emoji" => { "foo" => "https://x/y.png" })
+    end
+
+    it "raises a clear error on a non-200 response" do
+      stub_request(:get, "https://slack.com/api/auth.test")
+        .to_return(status: 500, body: "boom")
+
+      expect { described_class.call(token: token, path: "auth.test") }
+        .to raise_error(/Slack HTTP 500/)
+    end
+
+    it "raises on a transport failure" do
+      stub_request(:get, "https://slack.com/api/auth.test")
+        .to_raise(Errno::ECONNREFUSED)
+
+      expect { described_class.call(token: token, path: "auth.test") }
+        .to raise_error(Errno::ECONNREFUSED)
+    end
+  end
+end

--- a/spec/slack_status_cli/slack/http/get_request_spec.rb
+++ b/spec/slack_status_cli/slack/http/get_request_spec.rb
@@ -38,5 +38,15 @@ RSpec.describe SlackStatusCli::Slack::Http::GetRequest do
       expect { described_class.call(token: token, path: "auth.test") }
         .to raise_error(Errno::ECONNREFUSED)
     end
+
+    it "refuses an absolute-URL path that would override the Slack host" do
+      expect { described_class.call(token: token, path: "https://evil.example/steal") }
+        .to raise_error(ArgumentError, /relative Slack API method/)
+    end
+
+    it "refuses a leading-slash path that would escape the /api/ base" do
+      expect { described_class.call(token: token, path: "/auth.test") }
+        .to raise_error(ArgumentError, /relative Slack API method/)
+    end
   end
 end

--- a/spec/slack_status_cli/slack/http/post_request_spec.rb
+++ b/spec/slack_status_cli/slack/http/post_request_spec.rb
@@ -34,5 +34,15 @@ RSpec.describe SlackStatusCli::Slack::Http::PostRequest do
       expect(response).to be_a(Net::HTTPResponse)
       expect(response.body).to eq('{"ok":true}')
     end
+
+    it "refuses an absolute-URL path that would override the Slack host" do
+      expect { described_class.call(token: token, path: "https://evil.example/steal", body: body) }
+        .to raise_error(ArgumentError, /relative Slack API method/)
+    end
+
+    it "refuses a leading-slash path that would escape the /api/ base" do
+      expect { described_class.call(token: token, path: "/users.profile.set", body: body) }
+        .to raise_error(ArgumentError, /relative Slack API method/)
+    end
   end
 end

--- a/spec/slack_status_cli/slack/http/post_request_spec.rb
+++ b/spec/slack_status_cli/slack/http/post_request_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Slack::Http::PostRequest do
+  describe ".call" do
+    let(:token) { "xoxp-test-token-1234" }
+    let(:body) { '{"profile":{"status_text":"heads down"}}' }
+
+    it "POSTs to https://slack.com/api/<path> with bearer auth and the body" do
+      stub = stub_request(:post, "https://slack.com/api/users.profile.set")
+        .with(headers: { "Authorization" => "Bearer #{token}" }, body: body)
+        .to_return(status: 200, body: '{"ok":true}')
+
+      described_class.call(token: token, path: "users.profile.set", body: body)
+
+      expect(stub).to have_been_requested
+    end
+
+    it "sets Content-Type: application/json; charset=utf-8" do
+      stub = stub_request(:post, "https://slack.com/api/users.profile.set")
+        .with(headers: { "Content-Type" => "application/json; charset=utf-8" })
+        .to_return(status: 200, body: '{"ok":true}')
+
+      described_class.call(token: token, path: "users.profile.set", body: body)
+
+      expect(stub).to have_been_requested
+    end
+
+    it "returns the raw Net::HTTPResponse for the caller to log" do
+      stub_request(:post, "https://slack.com/api/users.profile.set")
+        .to_return(status: 200, body: '{"ok":true}')
+
+      response = described_class.call(token: token, path: "users.profile.set", body: body)
+
+      expect(response).to be_a(Net::HTTPResponse)
+      expect(response.body).to eq('{"ok":true}')
+    end
+  end
+end


### PR DESCRIPTION
Closes #20

## Purpose
Extracts the Slack HTTP boundary out of `lib/slack.rb` into two focused Callables under `Slack::Http`. `GetRequest` wraps GET-friendly endpoints (auth.test, emoji.list), returning parsed JSON and raising on non-2xx/transport failure. `PostRequest` wraps users.profile.set, returning the raw `Net::HTTPResponse` so the caller (ResponseLogger) owns ok/non-ok handling.

## Test plan
- [x] `bundle exec rspec spec/slack_status_cli/slack/http/` green (7 examples)
- [x] WebMock raises on any unstubbed HTTP attempt (no real network)
- [x] GetRequest: bearer auth, parsed JSON, non-200 raise, transport-failure raise
- [x] PostRequest: bearer auth + body, Content-Type header, raw response passthrough

## Commit plan
1. feat(slack-http): Add GetRequest Callable + WebMock spec
2. feat(slack-http): Add PostRequest Callable + WebMock spec
3. refactor(slack-http): Rename TLS block var to https in GetRequest

Made with [Cursor](https://cursor.com)

## Scope note — integration is deferred (by design)
This task extracts the HTTP boundary as standalone Callables only. The existing `lib/slack.rb` still uses its `slack_get` / inlined `Net::HTTP::Post`; that's intentional. Wiring happens in the next tasks:
- #21 (T2.5) — `AuthTest` / `EmojiList` queries build on `GetRequest`.
- #22 (T2.6) — dispatcher rewrite + delete `lib/slack.rb`.

## Security hardening (post-review)
Both Callables reject host-overriding `path` inputs: the URI is built by appending `path` to a fixed `https://slack.com/api/` base, and any absolute / scheme-relative / leading-slash path raises `ArgumentError` before a request is made, so the bearer token (and POST body) can never be redirected off-host. Added 4 specs (2 per Callable).
