### PR TITLE
feat(slack): Slack queries + leaf commands (AuthTest, EmojiList, SetStatus, ClearStatus)

### DIFF
--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -31,5 +31,9 @@ module SlackStatusCli
       autoload :AuthTest, "slack_status_cli/slack/queries/auth_test"
       autoload :EmojiList, "slack_status_cli/slack/queries/emoji_list"
     end
+
+    module Commands
+      autoload :SetStatus, "slack_status_cli/slack/commands/set_status"
+    end
   end
 end

--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -26,5 +26,9 @@ module SlackStatusCli
       autoload :GetRequest, "slack_status_cli/slack/http/get_request"
       autoload :PostRequest, "slack_status_cli/slack/http/post_request"
     end
+
+    module Queries
+      autoload :AuthTest, "slack_status_cli/slack/queries/auth_test"
+    end
   end
 end

--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -34,6 +34,7 @@ module SlackStatusCli
 
     module Commands
       autoload :SetStatus, "slack_status_cli/slack/commands/set_status"
+      autoload :ClearStatus, "slack_status_cli/slack/commands/clear_status"
     end
   end
 end

--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -29,6 +29,7 @@ module SlackStatusCli
 
     module Queries
       autoload :AuthTest, "slack_status_cli/slack/queries/auth_test"
+      autoload :EmojiList, "slack_status_cli/slack/queries/emoji_list"
     end
   end
 end

--- a/lib/slack_status_cli/slack/commands/clear_status.rb
+++ b/lib/slack_status_cli/slack/commands/clear_status.rb
@@ -1,0 +1,24 @@
+module SlackStatusCli
+  module Slack
+    module Commands
+      # Clears the Slack user status by delegating to SetStatus with an empty
+      # text/emoji and a zero expiration, which Slack interprets as "no status".
+      class ClearStatus
+        extend Callable
+
+        def initialize(token:, output: $stdout)
+          @token = token
+          @output = output
+        end
+
+        def call
+          SetStatus.call(token: token, text: "", emoji: "", expiration: 0, output: output)
+        end
+
+        private
+
+        attr_reader :token, :output
+      end
+    end
+  end
+end

--- a/lib/slack_status_cli/slack/commands/set_status.rb
+++ b/lib/slack_status_cli/slack/commands/set_status.rb
@@ -1,0 +1,38 @@
+module SlackStatusCli
+  module Slack
+    module Commands
+      # Sets the Slack user status. Builds the users.profile.set body via
+      # Builders::StatusPayload, POSTs it through Http::PostRequest, hands the
+      # raw response to Formatters::ResponseLogger, and returns that response so
+      # callers can inspect it. `now:` is injectable for deterministic specs.
+      class SetStatus
+        extend Callable
+
+        PATH = "users.profile.set".freeze
+
+        def initialize(token:, text:, emoji:, expiration:, output: $stdout, now: Time.now)
+          @token = token
+          @text = text
+          @emoji = emoji
+          @expiration = expiration
+          @output = output
+          @now = now
+        end
+
+        def call
+          response = Http::PostRequest.call(token: token, path: PATH, body: payload)
+          Formatters::ResponseLogger.call(response: response, output: output)
+          response
+        end
+
+        private
+
+        attr_reader :token, :text, :emoji, :expiration, :output, :now
+
+        def payload
+          Builders::StatusPayload.call(text: text, emoji: emoji, expiration: expiration, now: now)
+        end
+      end
+    end
+  end
+end

--- a/lib/slack_status_cli/slack/queries/auth_test.rb
+++ b/lib/slack_status_cli/slack/queries/auth_test.rb
@@ -1,0 +1,26 @@
+module SlackStatusCli
+  module Slack
+    module Queries
+      # Calls auth.test to validate the token and resolve the workspace/user it
+      # belongs to. Returns the parsed JSON response on success and lets
+      # Http::GetRequest raise on any non-2xx response.
+      class AuthTest
+        extend Callable
+
+        PATH = "auth.test".freeze
+
+        def initialize(token:)
+          @token = token
+        end
+
+        def call
+          Http::GetRequest.call(token: token, path: PATH)
+        end
+
+        private
+
+        attr_reader :token
+      end
+    end
+  end
+end

--- a/lib/slack_status_cli/slack/queries/emoji_list.rb
+++ b/lib/slack_status_cli/slack/queries/emoji_list.rb
@@ -1,0 +1,26 @@
+module SlackStatusCli
+  module Slack
+    module Queries
+      # Calls emoji.list and returns the parsed JSON. Requires the emoji:read
+      # scope on the user token. Each value in the returned "emoji" map is either
+      # an HTTPS URL (real custom emoji) or "alias:<other_name>".
+      class EmojiList
+        extend Callable
+
+        PATH = "emoji.list".freeze
+
+        def initialize(token:)
+          @token = token
+        end
+
+        def call
+          Http::GetRequest.call(token: token, path: PATH)
+        end
+
+        private
+
+        attr_reader :token
+      end
+    end
+  end
+end

--- a/spec/slack_status_cli/slack/commands/clear_status_spec.rb
+++ b/spec/slack_status_cli/slack/commands/clear_status_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+require "json"
+require "stringio"
+
+RSpec.describe SlackStatusCli::Slack::Commands::ClearStatus do
+  describe ".call" do
+    let(:token) { "xoxp-test-token-1234" }
+    let(:output) { StringIO.new }
+
+    it "POSTs an empty status payload (text='', emoji='', expiration=0)" do
+      stub = stub_request(:post, "https://slack.com/api/users.profile.set")
+        .with(
+          headers: { "Authorization" => "Bearer #{token}" },
+          body: { profile: { status_text: "", status_emoji: "", status_expiration: 0 } }.to_json
+        )
+        .to_return(status: 200, body: '{"ok":true}')
+
+      described_class.call(token: token, output: output)
+
+      expect(stub).to have_been_requested
+    end
+
+    it "delegates to SetStatus with the empty-status arguments" do
+      expect(SlackStatusCli::Slack::Commands::SetStatus)
+        .to receive(:call).with(token: token, text: "", emoji: "", expiration: 0, output: output)
+
+      described_class.call(token: token, output: output)
+    end
+  end
+end

--- a/spec/slack_status_cli/slack/commands/set_status_spec.rb
+++ b/spec/slack_status_cli/slack/commands/set_status_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+require "json"
+require "stringio"
+
+RSpec.describe SlackStatusCli::Slack::Commands::SetStatus do
+  describe ".call" do
+    let(:token) { "xoxp-test-token-1234" }
+    let(:output) { StringIO.new }
+
+    it "POSTs the expected JSON payload to users.profile.set" do
+      stub = stub_request(:post, "https://slack.com/api/users.profile.set")
+        .with(
+          headers: { "Authorization" => "Bearer #{token}" },
+          body: { profile: { status_text: "heads down", status_emoji: ":wolf:", status_expiration: 0 } }.to_json
+        )
+        .to_return(status: 200, body: '{"ok":true}')
+
+      described_class.call(token: token, text: "heads down", emoji: ":wolf:", expiration: nil, output: output)
+
+      expect(stub).to have_been_requested
+    end
+
+    it "expands a relative expiration via Builders::StatusPayload" do
+      now = Time.at(1_700_000_000)
+      stub = stub_request(:post, "https://slack.com/api/users.profile.set")
+        .with(
+          body: { profile: { status_text: "lunch", status_emoji: ":meat_on_bone:", status_expiration: now.to_i + (30 * 60) } }.to_json
+        )
+        .to_return(status: 200, body: '{"ok":true}')
+
+      described_class.call(token: token, text: "lunch", emoji: ":meat_on_bone:", expiration: "30m", now: now, output: output)
+
+      expect(stub).to have_been_requested
+    end
+
+    it "delegates response logging to Formatters::ResponseLogger" do
+      stub_request(:post, "https://slack.com/api/users.profile.set")
+        .to_return(status: 200, body: '{"ok":true}')
+      expect(SlackStatusCli::Slack::Formatters::ResponseLogger)
+        .to receive(:call).with(response: instance_of(Net::HTTPOK), output: output)
+
+      described_class.call(token: token, text: "heads down", emoji: ":wolf:", expiration: nil, output: output)
+    end
+
+    it "returns the raw Net::HTTPResponse" do
+      stub_request(:post, "https://slack.com/api/users.profile.set")
+        .to_return(status: 200, body: '{"ok":true}')
+
+      response = described_class.call(token: token, text: "", emoji: "", expiration: nil, output: output)
+
+      expect(response).to be_a(Net::HTTPResponse)
+    end
+  end
+end

--- a/spec/slack_status_cli/slack/queries/auth_test_spec.rb
+++ b/spec/slack_status_cli/slack/queries/auth_test_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Slack::Queries::AuthTest do
+  describe ".call" do
+    let(:token) { "xoxp-test-token-1234" }
+
+    it "hits auth.test with bearer auth" do
+      stub = stub_request(:get, "https://slack.com/api/auth.test")
+        .with(headers: { "Authorization" => "Bearer #{token}" })
+        .to_return(status: 200, body: build_slack_auth_response.to_json)
+
+      described_class.call(token: token)
+
+      expect(stub).to have_been_requested
+    end
+
+    it "returns the parsed JSON hash on success" do
+      auth = build_slack_auth_response(team: "Phoenix HQ", user: "efmcuiti")
+      stub_request(:get, "https://slack.com/api/auth.test")
+        .to_return(status: 200, body: auth.to_json)
+
+      expect(described_class.call(token: token)).to eq(auth)
+    end
+
+    it "raises on a non-200 response" do
+      stub_request(:get, "https://slack.com/api/auth.test")
+        .to_return(status: 401, body: "invalid_auth")
+
+      expect { described_class.call(token: token) }
+        .to raise_error(/Slack HTTP 401/)
+    end
+  end
+end

--- a/spec/slack_status_cli/slack/queries/emoji_list_spec.rb
+++ b/spec/slack_status_cli/slack/queries/emoji_list_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Slack::Queries::EmojiList do
+  describe ".call" do
+    let(:token) { "xoxp-test-token-1234" }
+
+    it "hits emoji.list with bearer auth" do
+      stub = stub_request(:get, "https://slack.com/api/emoji.list")
+        .with(headers: { "Authorization" => "Bearer #{token}" })
+        .to_return(status: 200, body: '{"ok":true,"emoji":{}}')
+
+      described_class.call(token: token)
+
+      expect(stub).to have_been_requested
+    end
+
+    it "returns the parsed JSON hash" do
+      body = { "ok" => true, "emoji" => { "phoenix_ash" => "https://x/y.png", "wolf" => "alias:dog" } }
+      stub_request(:get, "https://slack.com/api/emoji.list")
+        .to_return(status: 200, body: body.to_json)
+
+      expect(described_class.call(token: token)).to eq(body)
+    end
+  end
+end

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -2,4 +2,15 @@ module Factories
   def build_tune(state: :playing, name: "Aurora", artist: "Phoenix", album: "Bankrupt!")
     { state: state, name: name, artist: artist, album: album }
   end
+
+  def build_slack_auth_response(team: "Phoenix HQ", user: "efmcuiti", ok: true)
+    {
+      "ok" => ok,
+      "url" => "https://#{team.downcase.gsub(/\s+/, "-")}.slack.com/",
+      "team" => team,
+      "user" => user,
+      "team_id" => "T0123456789",
+      "user_id" => "U0123456789"
+    }
+  end
 end


### PR DESCRIPTION
Closes #21

## Purpose
Extracts the two read Queries (`AuthTest`, `EmojiList`) and the two leaf write Commands (`SetStatus`, `ClearStatus`) out of the monolithic `lib/slack.rb` into discrete Callables under the Slack pod. Queries wrap `Http::GetRequest`; `SetStatus` composes `Builders::StatusPayload` + `Http::PostRequest` + `Formatters::ResponseLogger`; `ClearStatus` delegates to `SetStatus` with an empty payload.

## Test plan
- [x] `bundle exec rspec spec/slack_status_cli/slack/queries/ spec/slack_status_cli/slack/commands/` green (11 examples)
- [x] Full suite green (114 examples, 0 failures)
- [x] No real network attempts (WebMock blocks anything unstubbed)
- [x] Relative expiration (e.g. `30m`) expands via `Builders::StatusPayload` with an injectable `now:`
- [x] `SetStatus` delegates response logging to `Formatters::ResponseLogger`

## Commit plan
1. feat(slack-queries): Add AuthTest Callable + WebMock spec
2. feat(slack-queries): Add EmojiList Callable + WebMock spec
3. feat(slack-commands): Add SetStatus Callable + WebMock spec
4. feat(slack-commands): Add ClearStatus Callable + WebMock spec (delegates to SetStatus)

Made with [Cursor](https://cursor.com)