### PR TITLE
feat(music): Extract Music pod queries (NowPlaying, AppleMusicFallback, TuneState, CurrentTrack)

### DIFF
--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -37,4 +37,15 @@ module SlackStatusCli
       autoload :ClearStatus, "slack_status_cli/slack/commands/clear_status"
     end
   end
+
+  module Music
+    autoload :Constants, "slack_status_cli/music/constants"
+
+    module Queries
+      autoload :NowPlaying, "slack_status_cli/music/queries/now_playing"
+      autoload :AppleMusicFallback, "slack_status_cli/music/queries/apple_music_fallback"
+      autoload :TuneState, "slack_status_cli/music/queries/tune_state"
+      autoload :CurrentTrack, "slack_status_cli/music/queries/current_track"
+    end
+  end
 end

--- a/lib/slack_status_cli/music/constants.rb
+++ b/lib/slack_status_cli/music/constants.rb
@@ -1,0 +1,27 @@
+module SlackStatusCli
+  module Music
+    # Shared null sentinels and the AppleScript fallback used by the Music
+    # queries. Extracted verbatim from the old `Music` class so the new
+    # Callable queries share a single source of truth for the "nothing is
+    # playing" shape and the osascript payload.
+    module Constants
+      NULL_RESPONSE = "null|null|null|null".freeze
+
+      NULL_TRACK = { name: nil, artist: nil, album: nil, playing: false }.freeze
+
+      SAFE_MUSIC_SCRIPT = <<~APPLESCRIPT.freeze
+        tell application "Music"
+          if not running then return "#{NULL_RESPONSE}"
+          if player state is stopped then return "#{NULL_RESPONSE}"
+          try
+            set t to current track
+            set s to (player state as text)
+            return s & "|" & (name of t) & "|" & (artist of t) & "|" & (album of t)
+          on error number -1728
+            return "#{NULL_RESPONSE}"
+          end try
+        end tell
+      APPLESCRIPT
+    end
+  end
+end

--- a/lib/slack_status_cli/music/queries/apple_music_fallback.rb
+++ b/lib/slack_status_cli/music/queries/apple_music_fallback.rb
@@ -1,0 +1,47 @@
+require "open3"
+
+module SlackStatusCli
+  module Music
+    module Queries
+      # Secondary now-playing source: drives the Music.app AppleScript
+      # (`Constants::SAFE_MUSIC_SCRIPT`) via `osascript` and parses its
+      # `state|name|artist|album` pipe output into a raw tune hash. Returns
+      # `Constants::NULL_TRACK` on shell failure or when nothing is playing.
+      # The shell collaborator is injected as `runner:` for spec ergonomics.
+      class AppleMusicFallback
+        extend Callable
+
+        def initialize(runner: Open3)
+          @runner = runner
+        end
+
+        def call
+          stdout, _stderr, status = runner.capture3("osascript", "-e", Constants::SAFE_MUSIC_SCRIPT)
+          return null_track unless status.success?
+
+          state, name, artist, album = stdout.strip.split("|").map { |part| nullify(part) }
+          return null_track if name.nil?
+
+          { name: name, artist: artist, album: album, playing: state == "playing" }
+        end
+
+        private
+
+        attr_reader :runner
+
+        def nullify(value)
+          return nil if value.nil?
+
+          stripped = value.to_s.strip
+          return nil if stripped.empty? || stripped == "null"
+
+          stripped
+        end
+
+        def null_track
+          Constants::NULL_TRACK.dup
+        end
+      end
+    end
+  end
+end

--- a/lib/slack_status_cli/music/queries/current_track.rb
+++ b/lib/slack_status_cli/music/queries/current_track.rb
@@ -1,0 +1,31 @@
+require "open3"
+
+module SlackStatusCli
+  module Music
+    module Queries
+      # Orchestrates the now-playing sources: tries `NowPlaying` first and
+      # returns its tune when something is playing, otherwise falls back to
+      # `AppleMusicFallback`. Returns `Constants::NULL_TRACK` when both
+      # sources come up empty. The shared `runner:` is threaded through to
+      # both queries so a single FakeShellRunner can stub the whole chain.
+      class CurrentTrack
+        extend Callable
+
+        def initialize(runner: Open3)
+          @runner = runner
+        end
+
+        def call
+          tune = NowPlaying.call(runner: runner)
+          return tune unless tune[:name].nil?
+
+          AppleMusicFallback.call(runner: runner)
+        end
+
+        private
+
+        attr_reader :runner
+      end
+    end
+  end
+end

--- a/lib/slack_status_cli/music/queries/current_track.rb
+++ b/lib/slack_status_cli/music/queries/current_track.rb
@@ -4,10 +4,11 @@ module SlackStatusCli
   module Music
     module Queries
       # Orchestrates the now-playing sources: tries `NowPlaying` first and
-      # returns its tune when something is playing, otherwise falls back to
-      # `AppleMusicFallback`. Returns `Constants::NULL_TRACK` when both
-      # sources come up empty. The shared `runner:` is threaded through to
-      # both queries so a single FakeShellRunner can stub the whole chain.
+      # returns its tune whenever it is non-null (a track with a name —
+      # playing or paused), otherwise falls back to `AppleMusicFallback`.
+      # Returns `Constants::NULL_TRACK` when both sources come up empty. The
+      # shared `runner:` is threaded through to both queries so a single
+      # FakeShellRunner can stub the whole chain.
       class CurrentTrack
         extend Callable
 

--- a/lib/slack_status_cli/music/queries/now_playing.rb
+++ b/lib/slack_status_cli/music/queries/now_playing.rb
@@ -22,7 +22,12 @@ module SlackStatusCli
         def call
           stdout, _stderr, status = runner.capture3(*COMMAND)
           return null_track unless status.success?
-
+        rescue Errno::ENOENT
+          # `nowplaying-cli` is not installed / not on PATH. Degrade to a
+          # silent tune instead of crashing the caller (the loop keeps
+          # ticking; the AppleScript fallback may still find a track).
+          null_track
+        else
           payload = parse_json(stdout)
           return null_track if payload.nil?
 

--- a/lib/slack_status_cli/music/queries/now_playing.rb
+++ b/lib/slack_status_cli/music/queries/now_playing.rb
@@ -1,0 +1,75 @@
+require "open3"
+require "json"
+
+module SlackStatusCli
+  module Music
+    module Queries
+      # Fetches the current track from MediaRemote via `nowplaying-cli`, the
+      # primary now-playing source. Returns a raw tune hash
+      # (`{ name:, artist:, album:, playing: }`) or `Constants::NULL_TRACK`
+      # when the command fails, the JSON is unparseable, or no title is set.
+      # The shell collaborator is injected as `runner:` so specs can drive it
+      # with a FakeShellRunner instead of spawning a process.
+      class NowPlaying
+        extend Callable
+
+        COMMAND = ["nowplaying-cli", "get", "--json", "title", "artist", "album", "playbackRate"].freeze
+
+        def initialize(runner: Open3)
+          @runner = runner
+        end
+
+        def call
+          stdout, _stderr, status = runner.capture3(*COMMAND)
+          return null_track unless status.success?
+
+          payload = parse_json(stdout)
+          return null_track if payload.nil?
+
+          title = nullify(payload["title"])
+          return null_track if title.nil?
+
+          {
+            name: title,
+            artist: nullify(payload["artist"]),
+            album: nullify(payload["album"]),
+            playing: playback_rate_to_playing(payload["playbackRate"])
+          }
+        end
+
+        private
+
+        attr_reader :runner
+
+        def parse_json(raw)
+          JSON.parse(raw.to_s.strip)
+        rescue JSON::ParserError
+          nil
+        end
+
+        # An explicit playbackRate of 0 means paused; a missing/nil rate falls
+        # back to "playing" to preserve prior behavior when MediaRemote omits
+        # the field.
+        def playback_rate_to_playing(rate)
+          return false if rate.is_a?(Numeric) && rate <= 0
+          return false if rate.is_a?(String) && rate.strip == "0"
+
+          true
+        end
+
+        def nullify(value)
+          return nil if value.nil?
+
+          stripped = value.to_s.strip
+          return nil if stripped.empty? || stripped == "null"
+
+          stripped
+        end
+
+        def null_track
+          Constants::NULL_TRACK.dup
+        end
+      end
+    end
+  end
+end

--- a/lib/slack_status_cli/music/queries/tune_state.rb
+++ b/lib/slack_status_cli/music/queries/tune_state.rb
@@ -1,0 +1,29 @@
+module SlackStatusCli
+  module Music
+    module Queries
+      # Pure derivation of a tune's playback state as a symbol
+      # (`:playing | :paused | :silent`) from a raw tune hash. No IO.
+      # A nil tune (an errored tick) defaults to `:playing` so callers keep
+      # the conservative cadence instead of hammering Slack during transient
+      # failures. Ported from the old `Slack#tune_state`.
+      class TuneState
+        extend Callable
+
+        def initialize(tune:)
+          @tune = tune
+        end
+
+        def call
+          return :playing if tune.nil?
+          return :silent if tune[:name].nil?
+
+          tune[:playing] ? :playing : :paused
+        end
+
+        private
+
+        attr_reader :tune
+      end
+    end
+  end
+end

--- a/spec/slack_status_cli/music/queries/apple_music_fallback_spec.rb
+++ b/spec/slack_status_cli/music/queries/apple_music_fallback_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Music::Queries::AppleMusicFallback do
+  describe ".call" do
+    let(:runner) { FakeShellRunner.new }
+    let(:script) { SlackStatusCli::Music::Constants::SAFE_MUSIC_SCRIPT }
+    let(:null_track) { SlackStatusCli::Music::Constants::NULL_TRACK }
+
+    it "runs SAFE_MUSIC_SCRIPT via osascript" do
+      runner.stub("osascript", stdout: "playing|Sirens|Cult of Luna|Vertikal")
+
+      described_class.call(runner: runner)
+
+      expect(runner.calls).to eq([["osascript", "-e", script]])
+    end
+
+    it "parses the pipe-delimited output into the tune hash" do
+      runner.stub("osascript", stdout: "playing|Sirens|Cult of Luna|Vertikal")
+
+      expect(described_class.call(runner: runner)).to eq(
+        name: "Sirens", artist: "Cult of Luna", album: "Vertikal", playing: true
+      )
+    end
+
+    it "marks the tune paused when the player state is not playing" do
+      runner.stub("osascript", stdout: "paused|Sirens|Cult of Luna|Vertikal")
+
+      expect(described_class.call(runner: runner)).to include(playing: false)
+    end
+
+    it "returns NULL_TRACK when osascript exits non-zero" do
+      runner.stub("osascript", stdout: "", stderr: "boom", success: false)
+
+      expect(described_class.call(runner: runner)).to eq(null_track)
+    end
+
+    it "returns NULL_TRACK when the script reports nothing playing" do
+      runner.stub("osascript", stdout: SlackStatusCli::Music::Constants::NULL_RESPONSE)
+
+      expect(described_class.call(runner: runner)).to eq(null_track)
+    end
+  end
+end

--- a/spec/slack_status_cli/music/queries/current_track_spec.rb
+++ b/spec/slack_status_cli/music/queries/current_track_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+require "json"
+
+RSpec.describe SlackStatusCli::Music::Queries::CurrentTrack do
+  describe ".call" do
+    let(:runner) { FakeShellRunner.new }
+    let(:null_track) { SlackStatusCli::Music::Constants::NULL_TRACK }
+
+    it "returns the NowPlaying tune when it is non-null" do
+      runner.stub(
+        "nowplaying-cli",
+        stdout: { "title" => "Sirens", "artist" => "Cult of Luna", "album" => "Vertikal", "playbackRate" => 1 }.to_json
+      )
+
+      result = described_class.call(runner: runner)
+
+      expect(result).to eq(name: "Sirens", artist: "Cult of Luna", album: "Vertikal", playing: true)
+      expect(runner.calls.map(&:first)).to eq(["nowplaying-cli"])
+    end
+
+    it "falls back to AppleMusicFallback when NowPlaying returns NULL_TRACK" do
+      runner.stub("nowplaying-cli", stdout: "", success: false)
+      runner.stub("osascript", stdout: "playing|Embers|Sojourner|Premonitions")
+
+      result = described_class.call(runner: runner)
+
+      expect(result).to eq(name: "Embers", artist: "Sojourner", album: "Premonitions", playing: true)
+      expect(runner.calls.map(&:first)).to eq(["nowplaying-cli", "osascript"])
+    end
+
+    it "returns NULL_TRACK when both sources are null" do
+      runner.stub("nowplaying-cli", stdout: "", success: false)
+      runner.stub("osascript", stdout: SlackStatusCli::Music::Constants::NULL_RESPONSE)
+
+      expect(described_class.call(runner: runner)).to eq(null_track)
+    end
+  end
+end

--- a/spec/slack_status_cli/music/queries/now_playing_spec.rb
+++ b/spec/slack_status_cli/music/queries/now_playing_spec.rb
@@ -51,5 +51,15 @@ RSpec.describe SlackStatusCli::Music::Queries::NowPlaying do
 
       expect(described_class.call(runner: runner)).to eq(null_track)
     end
+
+    it "returns NULL_TRACK when nowplaying-cli is not installed" do
+      missing_runner = Class.new do
+        def capture3(*)
+          raise Errno::ENOENT, "nowplaying-cli"
+        end
+      end.new
+
+      expect(described_class.call(runner: missing_runner)).to eq(null_track)
+    end
   end
 end

--- a/spec/slack_status_cli/music/queries/now_playing_spec.rb
+++ b/spec/slack_status_cli/music/queries/now_playing_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+require "json"
+
+RSpec.describe SlackStatusCli::Music::Queries::NowPlaying do
+  describe ".call" do
+    let(:runner) { FakeShellRunner.new }
+    let(:null_track) { SlackStatusCli::Music::Constants::NULL_TRACK }
+
+    def stub_payload(runner, payload, success: true)
+      runner.stub("nowplaying-cli", stdout: payload.to_json, success: success)
+    end
+
+    it "fetches the now-playing track via nowplaying-cli --json" do
+      stub_payload(runner, { "title" => "Sirens", "artist" => "Cult of Luna", "album" => "Vertikal", "playbackRate" => 1 })
+
+      described_class.call(runner: runner)
+
+      expect(runner.calls).to eq(
+        [["nowplaying-cli", "get", "--json", "title", "artist", "album", "playbackRate"]]
+      )
+    end
+
+    it "parses the JSON payload into the tune hash" do
+      stub_payload(runner, { "title" => "Sirens", "artist" => "Cult of Luna", "album" => "Vertikal", "playbackRate" => 1 })
+
+      expect(described_class.call(runner: runner)).to eq(
+        name: "Sirens", artist: "Cult of Luna", album: "Vertikal", playing: true
+      )
+    end
+
+    it "treats a playbackRate of 0 as paused" do
+      stub_payload(runner, { "title" => "Sirens", "artist" => "Cult of Luna", "album" => "Vertikal", "playbackRate" => 0 })
+
+      expect(described_class.call(runner: runner)).to include(playing: false)
+    end
+
+    it "returns NULL_TRACK when nowplaying-cli exits non-zero" do
+      runner.stub("nowplaying-cli", stdout: "", stderr: "boom", success: false)
+
+      expect(described_class.call(runner: runner)).to eq(null_track)
+    end
+
+    it "returns NULL_TRACK when stdout is empty or unparseable" do
+      runner.stub("nowplaying-cli", stdout: "")
+
+      expect(described_class.call(runner: runner)).to eq(null_track)
+    end
+
+    it "returns NULL_TRACK when the title is null" do
+      stub_payload(runner, { "title" => nil, "artist" => "Cult of Luna", "album" => "Vertikal", "playbackRate" => 1 })
+
+      expect(described_class.call(runner: runner)).to eq(null_track)
+    end
+  end
+end

--- a/spec/slack_status_cli/music/queries/tune_state_spec.rb
+++ b/spec/slack_status_cli/music/queries/tune_state_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Music::Queries::TuneState do
+  describe ".call" do
+    it "returns :playing when a named tune is actively playing" do
+      tune = { name: "Sirens", artist: "Cult of Luna", album: "Vertikal", playing: true }
+
+      expect(described_class.call(tune: tune)).to eq(:playing)
+    end
+
+    it "returns :paused when a named tune is not playing" do
+      tune = { name: "Sirens", artist: "Cult of Luna", album: "Vertikal", playing: false }
+
+      expect(described_class.call(tune: tune)).to eq(:paused)
+    end
+
+    it "returns :silent when the tune is NULL_TRACK" do
+      expect(described_class.call(tune: SlackStatusCli::Music::Constants::NULL_TRACK)).to eq(:silent)
+    end
+
+    it "defaults to :playing when the tune is nil (errored tick)" do
+      expect(described_class.call(tune: nil)).to eq(:playing)
+    end
+  end
+end


### PR DESCRIPTION
Closes #23

## Purpose
Splits the now-playing detection out of the monolithic `lib/music.rb` into four Callable Queries under a new `SlackStatusCli::Music` pod, plus a shared `Music::Constants` module. All shell access is injected via `runner:` so the queries are unit-testable with `FakeShellRunner` — no process spawning. `lib/music.rb` is left in place (its deletion is T3.2). This unblocks T2.6 (`TickMusicalStatus` calls `Music::Queries::CurrentTrack`).

## Test plan
- [x] `bundle exec rspec spec/slack_status_cli/music/` green (18 examples)
- [x] `NowPlaying` returns `NULL_TRACK` on non-zero exit, empty/unparseable stdout, and null title; parses JSON + treats `playbackRate` 0 as paused
- [x] `AppleMusicFallback` parses the `state|name|artist|album` pipe output and returns `NULL_TRACK` on shell failure / `NULL_RESPONSE`
- [x] `TuneState` derives `:playing | :paused | :silent` (and `:playing` for a nil errored tick)
- [x] `CurrentTrack` prefers `NowPlaying`, falls back to `AppleMusicFallback`, and never shells `osascript` when NowPlaying wins
- [x] Full suite green (132 examples)

## Commit plan
1. feat(music): Add Music::Constants module
2. feat(music-queries): Add NowPlaying Callable + spec (uses FakeShellRunner)
3. feat(music-queries): Add AppleMusicFallback Callable + spec (uses FakeShellRunner)
4. feat(music-queries): Add TuneState Callable + spec (pure, no runner)
5. feat(music-queries): Add CurrentTrack orchestrator Callable + spec

## Notes
- The issue's test-plan wording swapped the `NowPlaying` vs `AppleMusicFallback` source formats; specs follow the authoritative "Old code" mapping (`NowPlaying` = `nowplaying-cli --json`, `AppleMusicFallback` = `osascript` pipe).
- Queries produce the *raw* tune (`{ name:, artist:, album:, playing: }` / `NULL_TRACK`); the `:state`-keyed enriched shape the Slack formatters consume is composed later in T2.6.
- Dropped the old `puts` failure diagnostics — queries stay silent; logging belongs to the orchestrator.

Made with [Cursor](https://cursor.com)
