### PR TITLE
feat(tokens): Add Tokens::Errors module + Backends::Base

### DIFF
--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -41,6 +41,10 @@ module SlackStatusCli
     end
   end
 
+  module Tokens
+    autoload :Errors, "slack_status_cli/tokens/errors"
+  end
+
   module Music
     autoload :Constants, "slack_status_cli/music/constants"
 

--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -43,6 +43,10 @@ module SlackStatusCli
 
   module Tokens
     autoload :Errors, "slack_status_cli/tokens/errors"
+
+    module Backends
+      autoload :Base, "slack_status_cli/tokens/backends/base"
+    end
   end
 
   module Music

--- a/lib/slack_status_cli/tokens/backends/base.rb
+++ b/lib/slack_status_cli/tokens/backends/base.rb
@@ -1,0 +1,58 @@
+module SlackStatusCli
+  module Tokens
+    module Backends
+      # Abstract base for every token storage backend (Dashlane, Keychain,
+      # File, Env). Concrete backends extracted in T4.2 subclass this and
+      # implement `#read` / `#write`. The `#name` and `#source_label` defaults
+      # derive from the demodulized class name so a backend gets a sensible
+      # identifier and human label for free.
+      class Base
+        attr_reader :profile, :settings, :last_error
+
+        def initialize(profile:, settings: {})
+          @profile = profile
+          @settings = settings || {}
+          @last_error = nil
+        end
+
+        def read
+          raise NotImplementedError
+        end
+
+        def write(_token)
+          raise NotImplementedError
+        end
+
+        # Snake_case symbol identifier, e.g. KeychainBackend -> :keychain_backend.
+        def name
+          demodulized_name.to_sym
+        end
+
+        # Human-facing label, e.g. KeychainBackend -> "Keychain backend".
+        def source_label
+          demodulized_name.tr("_", " ").capitalize
+        end
+
+        def location
+          ""
+        end
+
+        # Backends override to explain WHY their read returned nil, including
+        # how the user can fix it. Surfaced by Errors::NotFoundError.
+        def not_found_hint
+          nil
+        end
+
+        private
+
+        def demodulized_name
+          self.class.name
+              .split("::")
+              .last
+              .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+              .downcase
+        end
+      end
+    end
+  end
+end

--- a/lib/slack_status_cli/tokens/errors.rb
+++ b/lib/slack_status_cli/tokens/errors.rb
@@ -1,0 +1,15 @@
+module SlackStatusCli
+  module Tokens
+    # Token-resolution error hierarchy, extracted verbatim from the old
+    # `TokenResolver::*Error` classes so the Tokens pod owns its own failure
+    # vocabulary. The legacy classes survive in `lib/token_resolver.rb` until
+    # the T4.5 cleanup.
+    module Errors
+      class Error < StandardError; end
+      class NotFoundError < Error; end
+      class ConfigError < Error; end
+      class ManualWriteRequired < Error; end
+      class WriteError < Error; end
+    end
+  end
+end

--- a/spec/slack_status_cli/tokens/backends/base_spec.rb
+++ b/spec/slack_status_cli/tokens/backends/base_spec.rb
@@ -1,0 +1,59 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Tokens::Backends::Base do
+  subject(:backend) { described_class.new(profile: "work") }
+
+  describe "#initialize" do
+    it "exposes the profile, settings, and a nil last_error" do
+      backend = described_class.new(profile: "work", settings: { "token_ref" => "dl://x" })
+
+      expect(backend.profile).to eq("work")
+      expect(backend.settings).to eq("token_ref" => "dl://x")
+      expect(backend.last_error).to be_nil
+    end
+
+    it "defaults settings to an empty hash" do
+      expect(described_class.new(profile: "work").settings).to eq({})
+    end
+  end
+
+  describe "#read" do
+    it "raises NotImplementedError (abstract)" do
+      expect { backend.read }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "#write" do
+    it "raises NotImplementedError (abstract)" do
+      expect { backend.write("xoxp-token") }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "#name" do
+    it "returns the demodulized class name as a snake_case symbol" do
+      stub_const("FakeKeychainBackend", Class.new(described_class))
+
+      expect(FakeKeychainBackend.new(profile: "work").name).to eq(:fake_keychain_backend)
+    end
+  end
+
+  describe "#source_label" do
+    it "returns the demodulized class name as a humanized sentence" do
+      stub_const("FakeKeychainBackend", Class.new(described_class))
+
+      expect(FakeKeychainBackend.new(profile: "work").source_label).to eq("Fake keychain backend")
+    end
+  end
+
+  describe "#location" do
+    it "defaults to an empty string" do
+      expect(backend.location).to eq("")
+    end
+  end
+
+  describe "#not_found_hint" do
+    it "defaults to nil" do
+      expect(backend.not_found_hint).to be_nil
+    end
+  end
+end

--- a/spec/slack_status_cli/tokens/errors_spec.rb
+++ b/spec/slack_status_cli/tokens/errors_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Tokens::Errors do
+  describe "Error" do
+    it "is a subclass of StandardError" do
+      expect(described_class::Error.ancestors).to include(StandardError)
+    end
+  end
+
+  describe "the specialized errors" do
+    it "all descend from Errors::Error" do
+      [
+        described_class::NotFoundError,
+        described_class::ConfigError,
+        described_class::ManualWriteRequired,
+        described_class::WriteError
+      ].each do |klass|
+        expect(klass.ancestors).to include(described_class::Error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #25

## Purpose
First task of Epic 4 (Tokens pod). Extracts the five `TokenResolver::*Error` classes into a dedicated `SlackStatusCli::Tokens::Errors` module, and lifts the abstract backend interface into `SlackStatusCli::Tokens::Backends::Base`. This stands up the namespace the four backend extractions in T4.2 will subclass. The legacy `TokenResolver::Backend` and error classes are intentionally left untouched in `lib/token_resolver.rb` (deleted in T4.5).

## Test plan
- [x] `bundle exec rspec spec/slack_status_cli/tokens/errors_spec.rb spec/slack_status_cli/tokens/backends/base_spec.rb` green
- [x] Full suite green (155 examples, 0 failures)
- [x] Errors hierarchy preserved (`NotFoundError/ConfigError/ManualWriteRequired/WriteError < Error < StandardError`)
- [x] `Base#read`/`#write` raise `NotImplementedError`; `#name` (snake_case symbol) and `#source_label` (humanized sentence) defaults derive from the demodulized class name

## Commit plan
1. feat(tokens): Add Tokens::Errors module + spec
2. feat(tokens-backends): Add Backends::Base abstract class + spec

Made with [Cursor](https://cursor.com)