### PR TITLE
feat(tokens): Extract config I/O callables — LoadConfig/MergedSettings/WriteConfig (T4.3)

### DIFF
--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -43,6 +43,11 @@ module SlackStatusCli
 
   module Tokens
     autoload :Errors, "slack_status_cli/tokens/errors"
+    autoload :Constants, "slack_status_cli/tokens/constants"
+
+    module Queries
+      autoload :LoadConfig, "slack_status_cli/tokens/queries/load_config"
+    end
 
     module Backends
       autoload :Base, "slack_status_cli/tokens/backends/base"

--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -47,6 +47,7 @@ module SlackStatusCli
 
     module Queries
       autoload :LoadConfig, "slack_status_cli/tokens/queries/load_config"
+      autoload :MergedSettings, "slack_status_cli/tokens/queries/merged_settings"
     end
 
     module Backends

--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -50,6 +50,10 @@ module SlackStatusCli
       autoload :MergedSettings, "slack_status_cli/tokens/queries/merged_settings"
     end
 
+    module Commands
+      autoload :WriteConfig, "slack_status_cli/tokens/commands/write_config"
+    end
+
     module Backends
       autoload :Base, "slack_status_cli/tokens/backends/base"
       autoload :Dashlane, "slack_status_cli/tokens/backends/dashlane"

--- a/lib/slack_status_cli/tokens/commands/write_config.rb
+++ b/lib/slack_status_cli/tokens/commands/write_config.rb
@@ -13,7 +13,7 @@ module SlackStatusCli
 
         def initialize(config:, path: Constants::DEFAULT_CONFIG_PATH)
           @config = config
-          @path = path
+          @path = ::File.expand_path(path)
         end
 
         def call

--- a/lib/slack_status_cli/tokens/commands/write_config.rb
+++ b/lib/slack_status_cli/tokens/commands/write_config.rb
@@ -17,11 +17,13 @@ module SlackStatusCli
         end
 
         def call
+          tmp = nil
+          created = false
+
           dir = ::File.dirname(path)
           ::FileUtils.mkdir_p(dir)
 
           tmp = ::File.join(dir, ".#{::File.basename(path)}.#{Process.pid}.#{rand(1_000_000)}.tmp")
-          created = false
           # O_EXCL + 0600 at creation closes the umask-dependent permission
           # window and refuses to follow a symlink pre-planted at the temp path.
           ::File.open(tmp, ::File::WRONLY | ::File::CREAT | ::File::EXCL, 0o600) do |file|
@@ -34,7 +36,7 @@ module SlackStatusCli
           # Only remove the temp file when THIS call created it — an EEXIST from
           # O_EXCL means something was already there, and deleting it would clobber
           # a file/symlink we don't own.
-          ::File.delete(tmp) if created && ::File.exist?(tmp)
+          ::File.delete(tmp) if tmp && created && ::File.exist?(tmp)
           raise
         end
 

--- a/lib/slack_status_cli/tokens/commands/write_config.rb
+++ b/lib/slack_status_cli/tokens/commands/write_config.rb
@@ -1,0 +1,47 @@
+require "fileutils"
+require "yaml"
+
+module SlackStatusCli
+  module Tokens
+    module Commands
+      # Persists the CLI config to disk as YAML, atomically: the payload is
+      # written to a sibling temp file (0600), then renamed over the target so a
+      # crash mid-write can never leave a half-written config. The parent
+      # directory is created if missing. Returns nil.
+      class WriteConfig
+        extend Callable
+
+        def initialize(config:, path: Constants::DEFAULT_CONFIG_PATH)
+          @config = config
+          @path = path
+        end
+
+        def call
+          dir = ::File.dirname(path)
+          ::FileUtils.mkdir_p(dir)
+
+          tmp = ::File.join(dir, ".#{::File.basename(path)}.#{Process.pid}.#{rand(1_000_000)}.tmp")
+          ::File.write(tmp, YAML.dump(deep_stringify(config)))
+          ::File.chmod(0o600, tmp)
+          ::File.rename(tmp, path)
+          nil
+        rescue StandardError
+          ::File.delete(tmp) if tmp && ::File.exist?(tmp)
+          raise
+        end
+
+        private
+
+        attr_reader :config, :path
+
+        def deep_stringify(obj)
+          case obj
+          when Hash then obj.each_with_object({}) { |(k, v), h| h[k.to_s] = deep_stringify(v) }
+          when Array then obj.map { |v| deep_stringify(v) }
+          else obj
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/slack_status_cli/tokens/commands/write_config.rb
+++ b/lib/slack_status_cli/tokens/commands/write_config.rb
@@ -21,8 +21,11 @@ module SlackStatusCli
           ::FileUtils.mkdir_p(dir)
 
           tmp = ::File.join(dir, ".#{::File.basename(path)}.#{Process.pid}.#{rand(1_000_000)}.tmp")
-          ::File.write(tmp, YAML.dump(deep_stringify(config)))
-          ::File.chmod(0o600, tmp)
+          # O_EXCL + 0600 at creation closes the umask-dependent permission
+          # window and refuses to follow a symlink pre-planted at the temp path.
+          ::File.open(tmp, ::File::WRONLY | ::File::CREAT | ::File::EXCL, 0o600) do |file|
+            file.write(YAML.dump(deep_stringify(config)))
+          end
           ::File.rename(tmp, path)
           nil
         rescue StandardError

--- a/lib/slack_status_cli/tokens/commands/write_config.rb
+++ b/lib/slack_status_cli/tokens/commands/write_config.rb
@@ -21,15 +21,20 @@ module SlackStatusCli
           ::FileUtils.mkdir_p(dir)
 
           tmp = ::File.join(dir, ".#{::File.basename(path)}.#{Process.pid}.#{rand(1_000_000)}.tmp")
+          created = false
           # O_EXCL + 0600 at creation closes the umask-dependent permission
           # window and refuses to follow a symlink pre-planted at the temp path.
           ::File.open(tmp, ::File::WRONLY | ::File::CREAT | ::File::EXCL, 0o600) do |file|
+            created = true
             file.write(YAML.dump(deep_stringify(config)))
           end
           ::File.rename(tmp, path)
           nil
         rescue StandardError
-          ::File.delete(tmp) if tmp && ::File.exist?(tmp)
+          # Only remove the temp file when THIS call created it — an EEXIST from
+          # O_EXCL means something was already there, and deleting it would clobber
+          # a file/symlink we don't own.
+          ::File.delete(tmp) if created && ::File.exist?(tmp)
           raise
         end
 

--- a/lib/slack_status_cli/tokens/constants.rb
+++ b/lib/slack_status_cli/tokens/constants.rb
@@ -1,0 +1,10 @@
+module SlackStatusCli
+  module Tokens
+    # Shared filesystem locations for the Tokens pod. Extracted from the legacy
+    # `TokenResolver` constants so the config-IO callables don't each re-derive
+    # the same paths.
+    module Constants
+      DEFAULT_CONFIG_PATH = ::File.expand_path("~/.config/slack-status-cli/config.yml").freeze
+    end
+  end
+end

--- a/lib/slack_status_cli/tokens/queries/load_config.rb
+++ b/lib/slack_status_cli/tokens/queries/load_config.rb
@@ -20,7 +20,13 @@ module SlackStatusCli
           return {} unless ::File.exist?(path)
 
           parsed = YAML.safe_load(::File.read(path), permitted_classes: [], aliases: false)
-          deep_stringify(parsed || {})
+          return {} if parsed.nil?
+
+          unless parsed.is_a?(Hash)
+            raise Errors::ConfigError, "#{path} is not a mapping (got #{parsed.class})"
+          end
+
+          deep_stringify(parsed)
         rescue Psych::Exception => e
           raise Errors::ConfigError, "Failed to parse #{path}: #{e.message}"
         end

--- a/lib/slack_status_cli/tokens/queries/load_config.rb
+++ b/lib/slack_status_cli/tokens/queries/load_config.rb
@@ -11,7 +11,7 @@ module SlackStatusCli
         extend Callable
 
         def initialize(path: Constants::DEFAULT_CONFIG_PATH)
-          @path = path
+          @path = ::File.expand_path(path)
         end
 
         attr_reader :path

--- a/lib/slack_status_cli/tokens/queries/load_config.rb
+++ b/lib/slack_status_cli/tokens/queries/load_config.rb
@@ -1,0 +1,40 @@
+require "yaml"
+
+module SlackStatusCli
+  module Tokens
+    module Queries
+      # Loads the CLI's YAML config from disk and returns it as a deep-stringified
+      # Hash. Missing or empty files yield `{}`; malformed YAML raises ConfigError.
+      # Keys are stringified so downstream callables (MergedSettings, the
+      # backends) never have to guard against symbol/integer keys.
+      class LoadConfig
+        extend Callable
+
+        def initialize(path: Constants::DEFAULT_CONFIG_PATH)
+          @path = path
+        end
+
+        attr_reader :path
+
+        def call
+          return {} unless ::File.exist?(path)
+
+          parsed = YAML.safe_load(::File.read(path), permitted_classes: [], aliases: false)
+          deep_stringify(parsed || {})
+        rescue Psych::Exception => e
+          raise Errors::ConfigError, "Failed to parse #{path}: #{e.message}"
+        end
+
+        private
+
+        def deep_stringify(obj)
+          case obj
+          when Hash then obj.each_with_object({}) { |(k, v), h| h[k.to_s] = deep_stringify(v) }
+          when Array then obj.map { |v| deep_stringify(v) }
+          else obj
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/slack_status_cli/tokens/queries/merged_settings.rb
+++ b/lib/slack_status_cli/tokens/queries/merged_settings.rb
@@ -1,0 +1,42 @@
+module SlackStatusCli
+  module Tokens
+    module Queries
+      # Computes the effective settings for a profile by deep-merging the
+      # `global:` defaults under the `profiles.<profile>` overrides (profile wins
+      # on collision). Modeled after `git config --global` inheritance. Hashes
+      # merge key-wise; every other value (including arrays) is overwritten
+      # wholesale by the profile side.
+      class MergedSettings
+        extend Callable
+
+        def initialize(config:, profile:)
+          @config = config || {}
+          @profile = profile
+        end
+
+        def call
+          global = config["global"] || {}
+          profile_settings = config.dig("profiles", profile) || {}
+          deep_merge(global, profile_settings)
+        end
+
+        private
+
+        attr_reader :config, :profile
+
+        def deep_merge(left, right)
+          return right.dup if left.nil? || left.empty?
+          return left.dup if right.nil? || right.empty?
+
+          left.merge(right) do |_key, left_value, right_value|
+            if left_value.is_a?(Hash) && right_value.is_a?(Hash)
+              deep_merge(left_value, right_value)
+            else
+              right_value
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/slack_status_cli/tokens/queries/merged_settings.rb
+++ b/lib/slack_status_cli/tokens/queries/merged_settings.rb
@@ -15,14 +15,25 @@ module SlackStatusCli
         end
 
         def call
-          global = config["global"] || {}
-          profile_settings = config.dig("profiles", profile) || {}
+          global = mapping(config["global"], "global")
+          profiles = mapping(config["profiles"], "profiles")
+          profile_settings = mapping(profiles[profile], "profiles.#{profile}")
           deep_merge(global, profile_settings)
         end
 
         private
 
         attr_reader :config, :profile
+
+        # Coerces a config node to a Hash, treating nil/absent as {} and raising
+        # a clear ConfigError when the node is some other type (e.g. `global: 1`
+        # or `profiles: []`) instead of letting deep_merge crash cryptically.
+        def mapping(value, label)
+          return {} if value.nil?
+          return value if value.is_a?(Hash)
+
+          raise Errors::ConfigError, "Expected `#{label}` to be a mapping, got #{value.class}"
+        end
 
         def deep_merge(left, right)
           return right.dup if left.nil? || left.empty?

--- a/spec/slack_status_cli/tokens/commands/write_config_spec.rb
+++ b/spec/slack_status_cli/tokens/commands/write_config_spec.rb
@@ -53,6 +53,19 @@ RSpec.describe SlackStatusCli::Tokens::Commands::WriteConfig do
       end
     end
 
+    it "does not delete a pre-existing file at the temp path on an O_EXCL collision" do
+      with_tmp_config do |dir:, path:|
+        command = described_class.new(config: build_config, path: path)
+        allow(command).to receive(:rand).and_return(123_456)
+        squatted = File.join(dir, ".#{File.basename(path)}.#{Process.pid}.123456.tmp")
+        File.write(squatted, "not mine")
+
+        expect { command.call }.to raise_error(Errno::EEXIST)
+
+        expect(File.read(squatted)).to eq("not mine")
+      end
+    end
+
     it "does not leave a temp file behind after a successful write" do
       with_tmp_config do |dir:, path:|
         described_class.call(config: build_config, path: path)

--- a/spec/slack_status_cli/tokens/commands/write_config_spec.rb
+++ b/spec/slack_status_cli/tokens/commands/write_config_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe SlackStatusCli::Tokens::Commands::WriteConfig do
       end
     end
 
-    it "creates the file with 0600 without relying on a post-write chmod (race-free)" do
+    it "creates the file with 0600 without a post-write chmod (race-free)" do
       with_tmp_config do |path:, **|
-        allow(File).to receive(:chmod)
+        expect(File).not_to receive(:chmod)
 
         described_class.call(config: build_config, path: path)
 

--- a/spec/slack_status_cli/tokens/commands/write_config_spec.rb
+++ b/spec/slack_status_cli/tokens/commands/write_config_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Tokens::Commands::WriteConfig do
+  describe ".call" do
+    it "writes the config so it round-trips through LoadConfig and returns nil" do
+      with_tmp_config do |path:, **|
+        config = build_config(global: { "storage_backend" => "keychain" })
+
+        result = described_class.call(config: config, path: path)
+
+        expect(result).to be_nil
+        expect(SlackStatusCli::Tokens::Queries::LoadConfig.call(path: path)).to eq(config)
+      end
+    end
+
+    it "creates the parent directory if it is missing" do
+      with_tmp_config do |dir:, **|
+        path = File.join(dir, "nested", "tree", "config.yml")
+
+        described_class.call(config: build_config, path: path)
+
+        expect(File.exist?(path)).to be(true)
+      end
+    end
+
+    it "writes with 0600 permissions" do
+      with_tmp_config do |path:, **|
+        described_class.call(config: build_config, path: path)
+
+        expect(File.stat(path).mode & 0o777).to eq(0o600)
+      end
+    end
+
+    it "leaves the existing config intact when the rename step fails (atomic)" do
+      with_tmp_config do |path:, **|
+        File.write(path, "old: data\n")
+        allow(File).to receive(:rename).and_raise(Errno::EXDEV)
+
+        expect { described_class.call(config: build_config(global: { "new" => "v" }), path: path) }
+          .to raise_error(Errno::EXDEV)
+
+        expect(File.read(path)).to eq("old: data\n")
+      end
+    end
+
+    it "does not leave a temp file behind after a successful write" do
+      with_tmp_config do |dir:, path:|
+        described_class.call(config: build_config, path: path)
+
+        leftovers = Dir.children(dir).reject { |name| name == File.basename(path) }
+        expect(leftovers).to be_empty
+      end
+    end
+  end
+end

--- a/spec/slack_status_cli/tokens/commands/write_config_spec.rb
+++ b/spec/slack_status_cli/tokens/commands/write_config_spec.rb
@@ -41,6 +41,20 @@ RSpec.describe SlackStatusCli::Tokens::Commands::WriteConfig do
       end
     end
 
+    it "expands a leading ~ in the path using HOME before writing" do
+      with_tmp_config do |dir:, **|
+        original_home = ENV["HOME"]
+        ENV["HOME"] = dir
+        Dir.chdir(dir) do
+          described_class.call(config: build_config, path: "~/nested/config.yml")
+
+          expect(File.exist?(File.join(dir, "nested", "config.yml"))).to be(true)
+        end
+      ensure
+        ENV["HOME"] = original_home
+      end
+    end
+
     it "leaves the existing config intact when the rename step fails (atomic)" do
       with_tmp_config do |path:, **|
         File.write(path, "old: data\n")

--- a/spec/slack_status_cli/tokens/commands/write_config_spec.rb
+++ b/spec/slack_status_cli/tokens/commands/write_config_spec.rb
@@ -55,6 +55,15 @@ RSpec.describe SlackStatusCli::Tokens::Commands::WriteConfig do
       end
     end
 
+    it "propagates the original error (not a NameError) when mkdir_p fails early" do
+      with_tmp_config do |path:, **|
+        allow(FileUtils).to receive(:mkdir_p).and_raise(Errno::EACCES, "denied")
+
+        expect { described_class.call(config: build_config, path: path) }
+          .to raise_error(Errno::EACCES)
+      end
+    end
+
     it "leaves the existing config intact when the rename step fails (atomic)" do
       with_tmp_config do |path:, **|
         File.write(path, "old: data\n")

--- a/spec/slack_status_cli/tokens/commands/write_config_spec.rb
+++ b/spec/slack_status_cli/tokens/commands/write_config_spec.rb
@@ -31,6 +31,16 @@ RSpec.describe SlackStatusCli::Tokens::Commands::WriteConfig do
       end
     end
 
+    it "creates the file with 0600 without relying on a post-write chmod (race-free)" do
+      with_tmp_config do |path:, **|
+        allow(File).to receive(:chmod)
+
+        described_class.call(config: build_config, path: path)
+
+        expect(File.stat(path).mode & 0o777).to eq(0o600)
+      end
+    end
+
     it "leaves the existing config intact when the rename step fails (atomic)" do
       with_tmp_config do |path:, **|
         File.write(path, "old: data\n")

--- a/spec/slack_status_cli/tokens/queries/load_config_spec.rb
+++ b/spec/slack_status_cli/tokens/queries/load_config_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Tokens::Queries::LoadConfig do
+  describe ".call" do
+    it "returns an empty hash when the path is missing" do
+      with_tmp_config do |dir:, **|
+        expect(described_class.call(path: File.join(dir, "absent.yml"))).to eq({})
+      end
+    end
+
+    it "returns the parsed hash when the path exists" do
+      with_tmp_config do |path:, **|
+        File.write(path, "global:\n  storage_backend: keychain\nprofiles: {}\n")
+
+        expect(described_class.call(path: path)).to eq(
+          "global" => { "storage_backend" => "keychain" },
+          "profiles" => {}
+        )
+      end
+    end
+
+    it "deep-stringifies non-string keys" do
+      with_tmp_config do |path:, **|
+        File.write(path, "1: one\n2: two\n")
+
+        expect(described_class.call(path: path)).to eq("1" => "one", "2" => "two")
+      end
+    end
+
+    it "returns an empty hash when the file is empty" do
+      with_tmp_config do |path:, **|
+        File.write(path, "")
+
+        expect(described_class.call(path: path)).to eq({})
+      end
+    end
+
+    it "raises ConfigError on malformed YAML" do
+      with_tmp_config do |path:, **|
+        File.write(path, "global: [1, 2\nprofiles:\n")
+
+        expect { described_class.call(path: path) }
+          .to raise_error(SlackStatusCli::Tokens::Errors::ConfigError, /Failed to parse/)
+      end
+    end
+
+    it "defaults to the Tokens default config path" do
+      expect(described_class.new.path).to eq(SlackStatusCli::Tokens::Constants::DEFAULT_CONFIG_PATH)
+    end
+  end
+end

--- a/spec/slack_status_cli/tokens/queries/load_config_spec.rb
+++ b/spec/slack_status_cli/tokens/queries/load_config_spec.rb
@@ -44,6 +44,24 @@ RSpec.describe SlackStatusCli::Tokens::Queries::LoadConfig do
       end
     end
 
+    it "raises ConfigError when the top-level YAML is a sequence, not a mapping" do
+      with_tmp_config do |path:, **|
+        File.write(path, "- a\n- b\n")
+
+        expect { described_class.call(path: path) }
+          .to raise_error(SlackStatusCli::Tokens::Errors::ConfigError, /not a mapping/)
+      end
+    end
+
+    it "raises ConfigError when the top-level YAML is a scalar, not a mapping" do
+      with_tmp_config do |path:, **|
+        File.write(path, "just a string\n")
+
+        expect { described_class.call(path: path) }
+          .to raise_error(SlackStatusCli::Tokens::Errors::ConfigError, /not a mapping/)
+      end
+    end
+
     it "defaults to the Tokens default config path" do
       expect(described_class.new.path).to eq(SlackStatusCli::Tokens::Constants::DEFAULT_CONFIG_PATH)
     end

--- a/spec/slack_status_cli/tokens/queries/load_config_spec.rb
+++ b/spec/slack_status_cli/tokens/queries/load_config_spec.rb
@@ -65,5 +65,10 @@ RSpec.describe SlackStatusCli::Tokens::Queries::LoadConfig do
     it "defaults to the Tokens default config path" do
       expect(described_class.new.path).to eq(SlackStatusCli::Tokens::Constants::DEFAULT_CONFIG_PATH)
     end
+
+    it "expands a leading ~ in the supplied path" do
+      expect(described_class.new(path: "~/.config/slack-status-cli/config.yml").path)
+        .to eq(File.expand_path("~/.config/slack-status-cli/config.yml"))
+    end
   end
 end

--- a/spec/slack_status_cli/tokens/queries/merged_settings_spec.rb
+++ b/spec/slack_status_cli/tokens/queries/merged_settings_spec.rb
@@ -39,5 +39,26 @@ RSpec.describe SlackStatusCli::Tokens::Queries::MergedSettings do
 
       expect(described_class.call(config: config, profile: "work")).to eq("x" => 1)
     end
+
+    it "raises ConfigError when the global node is not a mapping" do
+      config = { "global" => 1, "profiles" => {} }
+
+      expect { described_class.call(config: config, profile: "work") }
+        .to raise_error(SlackStatusCli::Tokens::Errors::ConfigError, /global/)
+    end
+
+    it "raises ConfigError when the profiles node is not a mapping" do
+      config = { "global" => {}, "profiles" => [] }
+
+      expect { described_class.call(config: config, profile: "work") }
+        .to raise_error(SlackStatusCli::Tokens::Errors::ConfigError, /profiles/)
+    end
+
+    it "raises ConfigError when the profile entry is not a mapping" do
+      config = { "global" => {}, "profiles" => { "work" => 5 } }
+
+      expect { described_class.call(config: config, profile: "work") }
+        .to raise_error(SlackStatusCli::Tokens::Errors::ConfigError, /work/)
+    end
   end
 end

--- a/spec/slack_status_cli/tokens/queries/merged_settings_spec.rb
+++ b/spec/slack_status_cli/tokens/queries/merged_settings_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Tokens::Queries::MergedSettings do
+  describe ".call" do
+    it "returns global defaults when the profile has no overrides" do
+      config = build_config(global: { "storage_backend" => "dashlane" }, profiles: {})
+
+      expect(described_class.call(config: config, profile: "work"))
+        .to eq("storage_backend" => "dashlane")
+    end
+
+    it "deep-merges profile overrides over global defaults" do
+      config = build_config(
+        global: { "storage_backend" => "dashlane", "oauth" => { "client_id" => "g" } },
+        profiles: { "work" => { "storage_backend" => "keychain", "oauth" => { "client_secret_ref" => "p" } } }
+      )
+
+      expect(described_class.call(config: config, profile: "work")).to eq(
+        "storage_backend" => "keychain",
+        "oauth" => { "client_id" => "g", "client_secret_ref" => "p" }
+      )
+    end
+
+    it "returns an empty hash when the config is empty" do
+      expect(described_class.call(config: {}, profile: "work")).to eq({})
+    end
+
+    it "preserves arrays exactly (overwrites, never element-merges)" do
+      config = build_config(
+        global: { "scopes" => %w[a b] },
+        profiles: { "work" => { "scopes" => %w[c] } }
+      )
+
+      expect(described_class.call(config: config, profile: "work")).to eq("scopes" => %w[c])
+    end
+
+    it "falls back to global defaults when the profile entry is absent" do
+      config = build_config(global: { "x" => 1 }, profiles: { "other" => { "y" => 2 } })
+
+      expect(described_class.call(config: config, profile: "work")).to eq("x" => 1)
+    end
+  end
+end

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -3,6 +3,10 @@ module Factories
     { state: state, name: name, artist: artist, album: album }
   end
 
+  def build_config(global: {}, profiles: {})
+    { "global" => global, "profiles" => profiles }
+  end
+
   def build_slack_auth_response(team: "Phoenix HQ", user: "efmcuiti", ok: true)
     {
       "ok" => ok,


### PR DESCRIPTION
Closes #27

## Purpose
Extracts the three config-IO concerns out of the `lib/token_resolver.rb` god class into dedicated Callables under the Tokens pod: `Queries::LoadConfig` (reads + deep-stringifies YAML, `{}` when missing, `ConfigError` on malformed), `Queries::MergedSettings` (deep-merges `global` defaults under `profiles.<profile>` overrides), and `Commands::WriteConfig` (atomic temp-file + rename, `0600`, returns `nil`). Adds `Tokens::Constants::DEFAULT_CONFIG_PATH` and a `build_config` spec factory. These are the building blocks #28 (`ResolveToken`/`WriteToken`) will consume.

## Test plan
- [x] `bundle exec rspec spec/slack_status_cli/tokens/queries/{load_config,merged_settings}_spec.rb spec/slack_status_cli/tokens/commands/write_config_spec.rb` green
- [x] `LoadConfig` returns `{}` for missing/empty, `ConfigError` on malformed YAML, deep-stringifies keys
- [x] `MergedSettings` overwrites arrays wholesale (no element-merge) and profile wins on collision
- [x] `WriteConfig` writes `0600` and is atomic (rename-failure leaves the existing file intact; no temp leftovers on success)
- [x] Full suite green (214 examples, 0 failures)

## Commit plan
1. feat(tokens-queries): Add LoadConfig query + Tokens constants + spec
2. feat(tokens-queries): Add MergedSettings query + build_config factory + spec
3. feat(tokens-commands): Add WriteConfig command with atomic write + spec

Made with [Cursor](https://cursor.com)