### PR TITLE
feat(tokens): Extract ResolveToken + WriteToken + 3 token-resolution helpers

### DIFF
--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -49,6 +49,7 @@ module SlackStatusCli
       autoload :LoadConfig, "slack_status_cli/tokens/queries/load_config"
       autoload :MergedSettings, "slack_status_cli/tokens/queries/merged_settings"
       autoload :EnvVarName, "slack_status_cli/tokens/queries/env_var_name"
+      autoload :ProfileExplicitlyConfigured, "slack_status_cli/tokens/queries/profile_explicitly_configured"
     end
 
     module Commands

--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -56,6 +56,7 @@ module SlackStatusCli
 
     module Commands
       autoload :WriteConfig, "slack_status_cli/tokens/commands/write_config"
+      autoload :WriteToken, "slack_status_cli/tokens/commands/write_token"
     end
 
     module Backends

--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -51,6 +51,7 @@ module SlackStatusCli
       autoload :EnvVarName, "slack_status_cli/tokens/queries/env_var_name"
       autoload :ProfileExplicitlyConfigured, "slack_status_cli/tokens/queries/profile_explicitly_configured"
       autoload :NotFoundMessage, "slack_status_cli/tokens/queries/not_found_message"
+      autoload :ResolveToken, "slack_status_cli/tokens/queries/resolve_token"
     end
 
     module Commands

--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -50,6 +50,7 @@ module SlackStatusCli
       autoload :MergedSettings, "slack_status_cli/tokens/queries/merged_settings"
       autoload :EnvVarName, "slack_status_cli/tokens/queries/env_var_name"
       autoload :ProfileExplicitlyConfigured, "slack_status_cli/tokens/queries/profile_explicitly_configured"
+      autoload :NotFoundMessage, "slack_status_cli/tokens/queries/not_found_message"
     end
 
     module Commands

--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -48,6 +48,7 @@ module SlackStatusCli
     module Queries
       autoload :LoadConfig, "slack_status_cli/tokens/queries/load_config"
       autoload :MergedSettings, "slack_status_cli/tokens/queries/merged_settings"
+      autoload :EnvVarName, "slack_status_cli/tokens/queries/env_var_name"
     end
 
     module Commands

--- a/lib/slack_status_cli/tokens/commands/write_token.rb
+++ b/lib/slack_status_cli/tokens/commands/write_token.rb
@@ -1,0 +1,49 @@
+module SlackStatusCli
+  module Tokens
+    module Commands
+      # Persists a token through the named storage backend, built from the
+      # already-merged settings the caller passes in. Extracted from the legacy
+      # `TokenResolver#write_token`. Returns `{ source:, location: }` so the
+      # caller can tell the user where the token landed; backends that can't
+      # write unattended (Env, Dashlane) raise ManualWriteRequired with
+      # copy-paste instructions instead.
+      class WriteToken
+        extend Callable
+
+        BACKEND_CLASSES = {
+          "dashlane" => Backends::Dashlane,
+          "keychain" => Backends::Keychain,
+          "file" => Backends::File,
+          "env" => Backends::Env
+        }.freeze
+
+        def initialize(token:, profile:, backend_name:, settings:)
+          @token = token
+          @profile = profile
+          @backend_name = backend_name
+          @settings = settings || {}
+        end
+
+        def call
+          backend = build_backend
+          backend.write(token)
+          { source: backend.source_label, location: backend.location }
+        end
+
+        private
+
+        attr_reader :token, :profile, :backend_name, :settings
+
+        def build_backend
+          klass = BACKEND_CLASSES[backend_name.to_s]
+          unless klass
+            raise Errors::ConfigError,
+                  "Unknown storage_backend '#{backend_name}' (supported: #{BACKEND_CLASSES.keys.join(', ')})"
+          end
+
+          klass.new(profile: profile, settings: settings)
+        end
+      end
+    end
+  end
+end

--- a/lib/slack_status_cli/tokens/commands/write_token.rb
+++ b/lib/slack_status_cli/tokens/commands/write_token.rb
@@ -38,7 +38,7 @@ module SlackStatusCli
           klass = BACKEND_CLASSES[backend_name.to_s]
           unless klass
             raise Errors::ConfigError,
-                  "Unknown storage_backend '#{backend_name}' (supported: #{BACKEND_CLASSES.keys.join(', ')})"
+                  "Unknown backend_name '#{backend_name}' (supported: #{BACKEND_CLASSES.keys.join(', ')})"
           end
 
           klass.new(profile: profile, settings: settings)

--- a/lib/slack_status_cli/tokens/queries/env_var_name.rb
+++ b/lib/slack_status_cli/tokens/queries/env_var_name.rb
@@ -4,9 +4,10 @@ module SlackStatusCli
       # Derives the profile-scoped environment variable name a token can be read
       # from, e.g. profile "default" -> "SLACK_STATUS_TOKEN_DEFAULT". The profile
       # is upcased and each non-alphanumeric character is replaced with its own
-      # underscore (so "my  work" -> "MY__WORK") to keep names shell-safe. Matches
-      # the Env backend's default key derivation, which the backend can still
-      # override via settings, so the precedence walker and the backend agree.
+      # underscore (so "my  work" -> "MY__WORK") to keep names shell-safe. This is
+      # the key the precedence walker checks at the ENV step; it matches the Env
+      # backend's *default* key derivation, but the two diverge when the backend
+      # reads/writes a custom key via `backend_options.env.var`.
       class EnvVarName
         extend Callable
 

--- a/lib/slack_status_cli/tokens/queries/env_var_name.rb
+++ b/lib/slack_status_cli/tokens/queries/env_var_name.rb
@@ -3,9 +3,10 @@ module SlackStatusCli
     module Queries
       # Derives the profile-scoped environment variable name a token can be read
       # from, e.g. profile "default" -> "SLACK_STATUS_TOKEN_DEFAULT". The profile
-      # is upcased and each non-alphanumeric character is replaced with its own
-      # underscore (so "my  work" -> "MY__WORK") to keep names shell-safe. This is
-      # the key the precedence walker checks at the ENV step; it matches the Env
+      # is upcased and any character outside [A-Z0-9_] is replaced with its own
+      # underscore (so "my  work" -> "MY__WORK"); existing underscores pass
+      # through unchanged, keeping names shell-safe. This is the key the
+      # precedence walker checks at the ENV step; it matches the Env
       # backend's *default* key derivation, but the two diverge when the backend
       # reads/writes a custom key via `backend_options.env.var`.
       class EnvVarName

--- a/lib/slack_status_cli/tokens/queries/env_var_name.rb
+++ b/lib/slack_status_cli/tokens/queries/env_var_name.rb
@@ -1,0 +1,30 @@
+module SlackStatusCli
+  module Tokens
+    module Queries
+      # Derives the profile-scoped environment variable name a token can be read
+      # from, e.g. profile "default" -> "SLACK_STATUS_TOKEN_DEFAULT". The profile
+      # is upcased and every non-alphanumeric character is collapsed to a single
+      # underscore so names stay shell-safe. Mirrors the Env backend's own key
+      # derivation so the precedence walker and the backend agree.
+      class EnvVarName
+        extend Callable
+
+        def initialize(profile:)
+          @profile = profile
+        end
+
+        def call
+          "SLACK_STATUS_TOKEN_#{sanitized_profile}"
+        end
+
+        private
+
+        attr_reader :profile
+
+        def sanitized_profile
+          profile.to_s.upcase.gsub(/[^A-Z0-9_]/, "_")
+        end
+      end
+    end
+  end
+end

--- a/lib/slack_status_cli/tokens/queries/env_var_name.rb
+++ b/lib/slack_status_cli/tokens/queries/env_var_name.rb
@@ -3,9 +3,10 @@ module SlackStatusCli
     module Queries
       # Derives the profile-scoped environment variable name a token can be read
       # from, e.g. profile "default" -> "SLACK_STATUS_TOKEN_DEFAULT". The profile
-      # is upcased and every non-alphanumeric character is collapsed to a single
-      # underscore so names stay shell-safe. Mirrors the Env backend's own key
-      # derivation so the precedence walker and the backend agree.
+      # is upcased and each non-alphanumeric character is replaced with its own
+      # underscore (so "my  work" -> "MY__WORK") to keep names shell-safe. Matches
+      # the Env backend's default key derivation, which the backend can still
+      # override via settings, so the precedence walker and the backend agree.
       class EnvVarName
         extend Callable
 

--- a/lib/slack_status_cli/tokens/queries/not_found_message.rb
+++ b/lib/slack_status_cli/tokens/queries/not_found_message.rb
@@ -1,0 +1,75 @@
+module SlackStatusCli
+  module Tokens
+    module Queries
+      # Builds the multi-line, human-facing message raised as NotFoundError when
+      # no token resolves for a profile. Extracted verbatim from the legacy
+      # `TokenResolver#friendly_not_found_message`: it names the profile, surfaces
+      # the tried backend's own not_found_hint (or, for an unconfigured
+      # non-default profile, points at the config path), lists the three
+      # remediation steps, and explains when SLACK_SECRET_TOKEN is being ignored
+      # on purpose to avoid cross-workspace token leakage.
+      class NotFoundMessage
+        extend Callable
+
+        DEFAULT_PROFILE = "default".freeze
+        LEGACY_ENV_VAR = "SLACK_SECRET_TOKEN".freeze
+
+        def initialize(profile:, config_path:, tried_backend: nil, profile_configured: false)
+          @profile = profile
+          @config_path = config_path
+          @tried_backend = tried_backend
+          @profile_configured = profile_configured
+        end
+
+        def call
+          lines = ["No Slack token found for profile '#{profile}'."]
+
+          if tried_backend
+            lines << "Tried #{tried_backend.source_label} but it returned no token."
+            hint = tried_backend.not_found_hint
+            hint.each_line { |line| lines << "  #{line.chomp}" } if hint
+          elsif !profile_configured && profile != DEFAULT_PROFILE
+            lines << "Profile '#{profile}' is not configured in #{config_path}."
+          end
+
+          lines.concat(remediation_steps)
+          lines.concat(legacy_note) if legacy_note?
+
+          lines.join("\n")
+        end
+
+        private
+
+        attr_reader :profile, :config_path, :tried_backend, :profile_configured
+
+        def remediation_steps
+          [
+            "",
+            "Fix one of:",
+            "  1. ruby slack_status.rb setup --profile #{profile}",
+            "  2. export #{EnvVarName.call(profile: profile)}=xoxp-... in your shell",
+            "  3. ruby slack_status.rb --token xoxp-... --profile #{profile} <mode>"
+          ]
+        end
+
+        def legacy_note?
+          non_empty?(ENV[LEGACY_ENV_VAR]) && (profile != DEFAULT_PROFILE || profile_configured)
+        end
+
+        def legacy_note
+          [
+            "",
+            "Note: SLACK_SECRET_TOKEN is set but intentionally ignored for",
+            "profile '#{profile}' to avoid sending a token from a different",
+            "workspace. The legacy fallback only applies to the `default`",
+            "profile when no backend is configured."
+          ]
+        end
+
+        def non_empty?(value)
+          !value.nil? && !value.to_s.strip.empty?
+        end
+      end
+    end
+  end
+end

--- a/lib/slack_status_cli/tokens/queries/not_found_message.rb
+++ b/lib/slack_status_cli/tokens/queries/not_found_message.rb
@@ -1,3 +1,5 @@
+require "shellwords"
+
 module SlackStatusCli
   module Tokens
     module Queries
@@ -47,12 +49,16 @@ module SlackStatusCli
         attr_reader :profile, :config_path, :tried_backend, :profile_configured, :legacy_env_present
 
         def remediation_steps
+          # Escape the profile only in the two copy-pasteable shell commands so a
+          # profile like "my work" stays valid when pasted; prose lines elsewhere
+          # keep the unescaped name for readability.
+          shell_profile = profile.to_s.shellescape
           [
             "",
             "Fix one of:",
-            "  1. ruby slack_status.rb setup --profile #{profile}",
+            "  1. ruby slack_status.rb setup --profile #{shell_profile}",
             "  2. export #{EnvVarName.call(profile: profile)}=xoxp-... in your shell",
-            "  3. ruby slack_status.rb --token xoxp-... --profile #{profile} <mode>"
+            "  3. ruby slack_status.rb --token xoxp-... --profile #{shell_profile} <mode>"
           ]
         end
 

--- a/lib/slack_status_cli/tokens/queries/not_found_message.rb
+++ b/lib/slack_status_cli/tokens/queries/not_found_message.rb
@@ -2,23 +2,27 @@ module SlackStatusCli
   module Tokens
     module Queries
       # Builds the multi-line, human-facing message raised as NotFoundError when
-      # no token resolves for a profile. Extracted verbatim from the legacy
+      # no token resolves for a profile. Extracted from the legacy
       # `TokenResolver#friendly_not_found_message`: it names the profile, surfaces
       # the tried backend's own not_found_hint (or, for an unconfigured
       # non-default profile, points at the config path), lists the three
       # remediation steps, and explains when SLACK_SECRET_TOKEN is being ignored
       # on purpose to avoid cross-workspace token leakage.
+      #
+      # Pure function of its inputs: the caller (ResolveToken) decides whether the
+      # legacy SLACK_SECRET_TOKEN is present and threads it in via
+      # `legacy_env_present:`, so this helper never reads process ENV itself.
       class NotFoundMessage
         extend Callable
 
         DEFAULT_PROFILE = "default".freeze
-        LEGACY_ENV_VAR = "SLACK_SECRET_TOKEN".freeze
 
-        def initialize(profile:, config_path:, tried_backend: nil, profile_configured: false)
+        def initialize(profile:, config_path:, tried_backend: nil, profile_configured: false, legacy_env_present: false)
           @profile = profile
           @config_path = config_path
           @tried_backend = tried_backend
           @profile_configured = profile_configured
+          @legacy_env_present = legacy_env_present
         end
 
         def call
@@ -40,7 +44,7 @@ module SlackStatusCli
 
         private
 
-        attr_reader :profile, :config_path, :tried_backend, :profile_configured
+        attr_reader :profile, :config_path, :tried_backend, :profile_configured, :legacy_env_present
 
         def remediation_steps
           [
@@ -53,7 +57,7 @@ module SlackStatusCli
         end
 
         def legacy_note?
-          non_empty?(ENV[LEGACY_ENV_VAR]) && (profile != DEFAULT_PROFILE || profile_configured)
+          legacy_env_present && (profile != DEFAULT_PROFILE || profile_configured)
         end
 
         def legacy_note
@@ -64,10 +68,6 @@ module SlackStatusCli
             "workspace. The legacy fallback only applies to the `default`",
             "profile when no backend is configured."
           ]
-        end
-
-        def non_empty?(value)
-          !value.nil? && !value.to_s.strip.empty?
         end
       end
     end

--- a/lib/slack_status_cli/tokens/queries/profile_explicitly_configured.rb
+++ b/lib/slack_status_cli/tokens/queries/profile_explicitly_configured.rb
@@ -1,0 +1,28 @@
+module SlackStatusCli
+  module Tokens
+    module Queries
+      # Answers whether a profile has its own explicit, non-empty block under
+      # `profiles.<profile>` in the config. Used by ResolveToken to gate the
+      # legacy SLACK_SECRET_TOKEN fallback: that fallback only applies to the
+      # `default` profile when nothing is explicitly configured, so an empty or
+      # absent block must read as "not configured".
+      class ProfileExplicitlyConfigured
+        extend Callable
+
+        def initialize(config:, profile:)
+          @config = config || {}
+          @profile = profile
+        end
+
+        def call
+          block = config.dig("profiles", profile)
+          block.is_a?(Hash) && !block.empty?
+        end
+
+        private
+
+        attr_reader :config, :profile
+      end
+    end
+  end
+end

--- a/lib/slack_status_cli/tokens/queries/resolve_token.rb
+++ b/lib/slack_status_cli/tokens/queries/resolve_token.rb
@@ -54,7 +54,8 @@ module SlackStatusCli
             profile: profile,
             config_path: config_path,
             tried_backend: backend,
-            profile_configured: profile_configured
+            profile_configured: profile_configured,
+            legacy_env_present: non_empty?(ENV[LEGACY_ENV_VAR])
           )
         end
 

--- a/lib/slack_status_cli/tokens/queries/resolve_token.rb
+++ b/lib/slack_status_cli/tokens/queries/resolve_token.rb
@@ -1,0 +1,106 @@
+module SlackStatusCli
+  module Tokens
+    module Queries
+      # The token precedence walker, extracted from the legacy
+      # `TokenResolver#resolve`. Returns the first non-empty token found,
+      # walking: cli_token -> SLACK_STATUS_TOKEN_<PROFILE> env -> the
+      # config-driven backend -> the legacy SLACK_SECRET_TOKEN fallback. Raises
+      # NotFoundError (carrying NotFoundMessage) when nothing resolves.
+      #
+      # The legacy SLACK_SECRET_TOKEN fallback is intentionally limited to the
+      # `default` profile when no profile block is configured and no backend
+      # resolved, so a token belonging to one workspace can never be silently
+      # injected for `--profile something-else`.
+      class ResolveToken
+        extend Callable
+
+        DEFAULT_PROFILE = "default".freeze
+        LEGACY_ENV_VAR = "SLACK_SECRET_TOKEN".freeze
+
+        BACKEND_CLASSES = {
+          "dashlane" => Backends::Dashlane,
+          "keychain" => Backends::Keychain,
+          "file" => Backends::File,
+          "env" => Backends::Env
+        }.freeze
+
+        def initialize(profile:, cli_token: nil, config_path: nil, verbose: false)
+          @profile = profile.to_s
+          @cli_token = cli_token
+          @config_path = config_path || Constants::DEFAULT_CONFIG_PATH
+          @verbose = verbose
+        end
+
+        def call
+          return success(cli_token, "cli:--token") if non_empty?(cli_token)
+
+          env_key = EnvVarName.call(profile: profile)
+          return success(ENV[env_key], "env:#{env_key}") if non_empty?(ENV[env_key])
+
+          config = LoadConfig.call(path: config_path)
+          profile_configured = ProfileExplicitlyConfigured.call(config: config, profile: profile)
+
+          backend = build_backend(config)
+          if backend
+            token = backend.read
+            return success(token, backend.source_label) if non_empty?(token)
+          end
+
+          if legacy_eligible?(profile_configured, backend) && non_empty?(ENV[LEGACY_ENV_VAR])
+            return success(ENV[LEGACY_ENV_VAR], "env:#{LEGACY_ENV_VAR}")
+          end
+
+          raise Errors::NotFoundError, NotFoundMessage.call(
+            profile: profile,
+            config_path: config_path,
+            tried_backend: backend,
+            profile_configured: profile_configured
+          )
+        end
+
+        private
+
+        attr_reader :profile, :cli_token, :config_path, :verbose
+
+        def build_backend(config)
+          settings = MergedSettings.call(config: config, profile: profile)
+          backend_name = settings["storage_backend"] || infer_default_backend(settings)
+          return nil unless backend_name
+
+          klass = BACKEND_CLASSES[backend_name.to_s]
+          unless klass
+            raise Errors::ConfigError,
+                  "Unknown storage_backend '#{backend_name}' (supported: #{BACKEND_CLASSES.keys.join(', ')})"
+          end
+
+          klass.new(profile: profile, settings: settings)
+        end
+
+        def infer_default_backend(settings)
+          return nil if settings.nil? || settings.empty?
+
+          "dashlane" if settings["token_ref"]
+        end
+
+        def legacy_eligible?(profile_configured, backend)
+          profile == DEFAULT_PROFILE && !profile_configured && backend.nil?
+        end
+
+        def success(token, source)
+          log_source(source)
+          { token: token.to_s.strip, source: source, profile: profile }
+        end
+
+        def log_source(source)
+          return unless verbose
+
+          warn "[slack-status-cli] token resolved from #{source} (profile=#{profile})"
+        end
+
+        def non_empty?(value)
+          !value.nil? && !value.to_s.strip.empty?
+        end
+      end
+    end
+  end
+end

--- a/spec/slack_status_cli/tokens/commands/write_token_spec.rb
+++ b/spec/slack_status_cli/tokens/commands/write_token_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Tokens::Commands::WriteToken do
+  describe ".call" do
+    it "delegates the write to the requested backend" do
+      with_tmp_config do |dir:, **|
+        token_path = File.join(dir, "work.token")
+        settings = { "backend_options" => { "file" => { "path" => token_path } } }
+
+        described_class.call(token: "xoxp-written", profile: "work", backend_name: "file", settings: settings)
+
+        expect(File.read(token_path).strip).to eq("xoxp-written")
+      end
+    end
+
+    it "returns { source:, location: } describing where the token landed" do
+      with_tmp_config do |dir:, **|
+        token_path = File.join(dir, "work.token")
+        settings = { "backend_options" => { "file" => { "path" => token_path } } }
+
+        result = described_class.call(token: "xoxp-x", profile: "work", backend_name: "file", settings: settings)
+
+        expect(result).to eq(source: "File", location: token_path)
+      end
+    end
+
+    it "raises ManualWriteRequired when the backend rejects programmatic writes (Env)" do
+      expect do
+        described_class.call(token: "xoxp-x", profile: "work", backend_name: "env", settings: {})
+      end.to raise_error(SlackStatusCli::Tokens::Errors::ManualWriteRequired, /SLACK_STATUS_TOKEN_WORK/)
+    end
+
+    it "raises ConfigError for an unknown backend_name" do
+      expect do
+        described_class.call(token: "xoxp-x", profile: "work", backend_name: "bogus", settings: {})
+      end.to raise_error(SlackStatusCli::Tokens::Errors::ConfigError, /bogus/)
+    end
+  end
+end

--- a/spec/slack_status_cli/tokens/queries/env_var_name_spec.rb
+++ b/spec/slack_status_cli/tokens/queries/env_var_name_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe SlackStatusCli::Tokens::Queries::EnvVarName do
       expect(described_class.call(profile: "work-account")).to eq("SLACK_STATUS_TOKEN_WORK_ACCOUNT")
     end
 
-    it "collapses any non-alphanumeric character to a single underscore" do
-      expect(described_class.call(profile: "my work")).to eq("SLACK_STATUS_TOKEN_MY_WORK")
+    it "replaces each non-alphanumeric character with its own underscore" do
+      expect(described_class.call(profile: "my  work")).to eq("SLACK_STATUS_TOKEN_MY__WORK")
     end
   end
 end

--- a/spec/slack_status_cli/tokens/queries/env_var_name_spec.rb
+++ b/spec/slack_status_cli/tokens/queries/env_var_name_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Tokens::Queries::EnvVarName do
+  describe ".call" do
+    it "returns SLACK_STATUS_TOKEN_DEFAULT for the default profile" do
+      expect(described_class.call(profile: "default")).to eq("SLACK_STATUS_TOKEN_DEFAULT")
+    end
+
+    it "uppercases and sanitizes non-default profile names" do
+      expect(described_class.call(profile: "work-account")).to eq("SLACK_STATUS_TOKEN_WORK_ACCOUNT")
+    end
+
+    it "collapses any non-alphanumeric character to a single underscore" do
+      expect(described_class.call(profile: "my work")).to eq("SLACK_STATUS_TOKEN_MY_WORK")
+    end
+  end
+end

--- a/spec/slack_status_cli/tokens/queries/not_found_message_spec.rb
+++ b/spec/slack_status_cli/tokens/queries/not_found_message_spec.rb
@@ -1,100 +1,79 @@
 require "spec_helper"
 
 RSpec.describe SlackStatusCli::Tokens::Queries::NotFoundMessage do
-  def without_env(key)
-    had = ENV.key?(key)
-    old = ENV[key]
-    ENV.delete(key)
-    yield
-  ensure
-    had ? ENV[key] = old : ENV.delete(key)
-  end
-
-  def with_env(key, value)
-    had = ENV.key?(key)
-    old = ENV[key]
-    ENV[key] = value
-    yield
-  ensure
-    had ? ENV[key] = old : ENV.delete(key)
-  end
-
   def env_backend(profile: "work")
     SlackStatusCli::Tokens::Backends::Env.new(profile: profile)
   end
 
   describe ".call" do
     it "mentions the profile name" do
-      without_env("SLACK_SECRET_TOKEN") do
-        message = described_class.call(
-          profile: "work", config_path: "/cfg.yml", tried_backend: nil, profile_configured: false
-        )
+      message = described_class.call(
+        profile: "work", config_path: "/cfg.yml", tried_backend: nil, profile_configured: false
+      )
 
-        expect(message).to include("profile 'work'")
-      end
+      expect(message).to include("profile 'work'")
     end
 
     it "mentions the config path when an unconfigured non-default profile has no backend" do
-      without_env("SLACK_SECRET_TOKEN") do
-        message = described_class.call(
-          profile: "work", config_path: "/home/me/config.yml", tried_backend: nil, profile_configured: false
-        )
+      message = described_class.call(
+        profile: "work", config_path: "/home/me/config.yml", tried_backend: nil, profile_configured: false
+      )
 
-        expect(message).to include("not configured in /home/me/config.yml")
-      end
+      expect(message).to include("not configured in /home/me/config.yml")
     end
 
     it "names the tried backend and surfaces its not_found_hint" do
-      without_env("SLACK_SECRET_TOKEN") do
-        message = described_class.call(
-          profile: "work", config_path: "/cfg.yml", tried_backend: env_backend, profile_configured: true
-        )
+      message = described_class.call(
+        profile: "work", config_path: "/cfg.yml", tried_backend: env_backend, profile_configured: true
+      )
 
-        expect(message).to include("Tried Env but it returned no token.")
-        expect(message).to include("Export SLACK_STATUS_TOKEN_WORK")
-      end
+      expect(message).to include("Tried Env but it returned no token.")
+      expect(message).to include("Export SLACK_STATUS_TOKEN_WORK")
     end
 
     it "omits the not-configured line when the profile is explicitly configured" do
-      without_env("SLACK_SECRET_TOKEN") do
-        message = described_class.call(
-          profile: "work", config_path: "/cfg.yml", tried_backend: nil, profile_configured: true
-        )
+      message = described_class.call(
+        profile: "work", config_path: "/cfg.yml", tried_backend: nil, profile_configured: true
+      )
 
-        expect(message).not_to include("not configured")
-      end
+      expect(message).not_to include("not configured")
     end
 
     it "always lists the three remediation steps using the profile-scoped env var" do
-      without_env("SLACK_SECRET_TOKEN") do
-        message = described_class.call(
-          profile: "work", config_path: "/cfg.yml", tried_backend: nil, profile_configured: false
-        )
+      message = described_class.call(
+        profile: "work", config_path: "/cfg.yml", tried_backend: nil, profile_configured: false
+      )
 
-        expect(message).to include("ruby slack_status.rb setup --profile work")
-        expect(message).to include("export SLACK_STATUS_TOKEN_WORK=xoxp-")
-        expect(message).to include("ruby slack_status.rb --token xoxp-... --profile work")
-      end
+      expect(message).to include("ruby slack_status.rb setup --profile work")
+      expect(message).to include("export SLACK_STATUS_TOKEN_WORK=xoxp-")
+      expect(message).to include("ruby slack_status.rb --token xoxp-... --profile work")
     end
 
-    it "appends the ignored SLACK_SECRET_TOKEN note for a non-default profile when it is set" do
-      with_env("SLACK_SECRET_TOKEN", "xoxp-legacy") do
-        message = described_class.call(
-          profile: "work", config_path: "/cfg.yml", tried_backend: nil, profile_configured: false
-        )
+    it "appends the ignored SLACK_SECRET_TOKEN note for a non-default profile when legacy_env_present" do
+      message = described_class.call(
+        profile: "work", config_path: "/cfg.yml", tried_backend: nil,
+        profile_configured: false, legacy_env_present: true
+      )
 
-        expect(message).to include("SLACK_SECRET_TOKEN is set but intentionally ignored")
-      end
+      expect(message).to include("SLACK_SECRET_TOKEN is set but intentionally ignored")
     end
 
     it "does not append the legacy note for the unconfigured default profile" do
-      with_env("SLACK_SECRET_TOKEN", "xoxp-legacy") do
-        message = described_class.call(
-          profile: "default", config_path: "/cfg.yml", tried_backend: nil, profile_configured: false
-        )
+      message = described_class.call(
+        profile: "default", config_path: "/cfg.yml", tried_backend: nil,
+        profile_configured: false, legacy_env_present: true
+      )
 
-        expect(message).not_to include("intentionally ignored")
-      end
+      expect(message).not_to include("intentionally ignored")
+    end
+
+    it "does not append the legacy note when legacy_env_present is false" do
+      message = described_class.call(
+        profile: "work", config_path: "/cfg.yml", tried_backend: nil,
+        profile_configured: false, legacy_env_present: false
+      )
+
+      expect(message).not_to include("intentionally ignored")
     end
   end
 end

--- a/spec/slack_status_cli/tokens/queries/not_found_message_spec.rb
+++ b/spec/slack_status_cli/tokens/queries/not_found_message_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SlackStatusCli::Tokens::Queries::NotFoundMessage do
     ENV.delete(key)
     yield
   ensure
-    ENV[key] = old if had
+    had ? ENV[key] = old : ENV.delete(key)
   end
 
   def with_env(key, value)

--- a/spec/slack_status_cli/tokens/queries/not_found_message_spec.rb
+++ b/spec/slack_status_cli/tokens/queries/not_found_message_spec.rb
@@ -49,6 +49,23 @@ RSpec.describe SlackStatusCli::Tokens::Queries::NotFoundMessage do
       expect(message).to include("ruby slack_status.rb --token xoxp-... --profile work")
     end
 
+    it "shell-escapes a profile with spaces in the remediation commands" do
+      message = described_class.call(
+        profile: "my work", config_path: "/cfg.yml", tried_backend: nil, profile_configured: false
+      )
+
+      expect(message).to include('setup --profile my\ work')
+      expect(message).to include('--token xoxp-... --profile my\ work')
+    end
+
+    it "leaves a simple profile unescaped in the remediation commands" do
+      message = described_class.call(
+        profile: "work", config_path: "/cfg.yml", tried_backend: nil, profile_configured: false
+      )
+
+      expect(message).to include("setup --profile work")
+    end
+
     it "appends the ignored SLACK_SECRET_TOKEN note for a non-default profile when legacy_env_present" do
       message = described_class.call(
         profile: "work", config_path: "/cfg.yml", tried_backend: nil,

--- a/spec/slack_status_cli/tokens/queries/not_found_message_spec.rb
+++ b/spec/slack_status_cli/tokens/queries/not_found_message_spec.rb
@@ -1,0 +1,100 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Tokens::Queries::NotFoundMessage do
+  def without_env(key)
+    had = ENV.key?(key)
+    old = ENV[key]
+    ENV.delete(key)
+    yield
+  ensure
+    ENV[key] = old if had
+  end
+
+  def with_env(key, value)
+    had = ENV.key?(key)
+    old = ENV[key]
+    ENV[key] = value
+    yield
+  ensure
+    had ? ENV[key] = old : ENV.delete(key)
+  end
+
+  def env_backend(profile: "work")
+    SlackStatusCli::Tokens::Backends::Env.new(profile: profile)
+  end
+
+  describe ".call" do
+    it "mentions the profile name" do
+      without_env("SLACK_SECRET_TOKEN") do
+        message = described_class.call(
+          profile: "work", config_path: "/cfg.yml", tried_backend: nil, profile_configured: false
+        )
+
+        expect(message).to include("profile 'work'")
+      end
+    end
+
+    it "mentions the config path when an unconfigured non-default profile has no backend" do
+      without_env("SLACK_SECRET_TOKEN") do
+        message = described_class.call(
+          profile: "work", config_path: "/home/me/config.yml", tried_backend: nil, profile_configured: false
+        )
+
+        expect(message).to include("not configured in /home/me/config.yml")
+      end
+    end
+
+    it "names the tried backend and surfaces its not_found_hint" do
+      without_env("SLACK_SECRET_TOKEN") do
+        message = described_class.call(
+          profile: "work", config_path: "/cfg.yml", tried_backend: env_backend, profile_configured: true
+        )
+
+        expect(message).to include("Tried Env but it returned no token.")
+        expect(message).to include("Export SLACK_STATUS_TOKEN_WORK")
+      end
+    end
+
+    it "omits the not-configured line when the profile is explicitly configured" do
+      without_env("SLACK_SECRET_TOKEN") do
+        message = described_class.call(
+          profile: "work", config_path: "/cfg.yml", tried_backend: nil, profile_configured: true
+        )
+
+        expect(message).not_to include("not configured")
+      end
+    end
+
+    it "always lists the three remediation steps using the profile-scoped env var" do
+      without_env("SLACK_SECRET_TOKEN") do
+        message = described_class.call(
+          profile: "work", config_path: "/cfg.yml", tried_backend: nil, profile_configured: false
+        )
+
+        expect(message).to include("ruby slack_status.rb setup --profile work")
+        expect(message).to include("export SLACK_STATUS_TOKEN_WORK=xoxp-")
+        expect(message).to include("ruby slack_status.rb --token xoxp-... --profile work")
+      end
+    end
+
+    it "appends the ignored SLACK_SECRET_TOKEN note for a non-default profile when it is set" do
+      with_env("SLACK_SECRET_TOKEN", "xoxp-legacy") do
+        message = described_class.call(
+          profile: "work", config_path: "/cfg.yml", tried_backend: nil, profile_configured: false
+        )
+
+        expect(message).to include("SLACK_SECRET_TOKEN is set but intentionally ignored")
+      end
+    end
+
+    it "does not append the legacy note for the unconfigured default profile" do
+      with_env("SLACK_SECRET_TOKEN", "xoxp-legacy") do
+        message = described_class.call(
+          profile: "default", config_path: "/cfg.yml", tried_backend: nil, profile_configured: false
+        )
+
+        expect(message).not_to include("intentionally ignored")
+      end
+    end
+  end
+end

--- a/spec/slack_status_cli/tokens/queries/profile_explicitly_configured_spec.rb
+++ b/spec/slack_status_cli/tokens/queries/profile_explicitly_configured_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Tokens::Queries::ProfileExplicitlyConfigured do
+  describe ".call" do
+    it "returns true when the profile has a non-empty block under profiles" do
+      config = build_config(profiles: { "work" => { "storage_backend" => "keychain" } })
+
+      expect(described_class.call(config: config, profile: "work")).to be(true)
+    end
+
+    it "returns false when the profile key is missing" do
+      config = build_config(profiles: { "other" => { "storage_backend" => "file" } })
+
+      expect(described_class.call(config: config, profile: "work")).to be(false)
+    end
+
+    it "returns false when the config is empty" do
+      expect(described_class.call(config: {}, profile: "work")).to be(false)
+    end
+
+    it "returns false when the profile block is present but empty" do
+      config = build_config(profiles: { "work" => {} })
+
+      expect(described_class.call(config: config, profile: "work")).to be(false)
+    end
+  end
+end

--- a/spec/slack_status_cli/tokens/queries/resolve_token_spec.rb
+++ b/spec/slack_status_cli/tokens/queries/resolve_token_spec.rb
@@ -1,0 +1,120 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Tokens::Queries::ResolveToken do
+  def with_env(key, value)
+    had = ENV.key?(key)
+    old = ENV[key]
+    ENV[key] = value
+    yield
+  ensure
+    had ? ENV[key] = old : ENV.delete(key)
+  end
+
+  def without_env(*keys)
+    saved = keys.map { |key| [key, ENV.key?(key), ENV[key]] }
+    keys.each { |key| ENV.delete(key) }
+    yield
+  ensure
+    saved.each { |key, had, old| ENV[key] = old if had }
+  end
+
+  def write_token_file(path, contents)
+    File.write(path, "#{contents}\n")
+    File.chmod(0o600, path)
+  end
+
+  describe ".call" do
+    it "returns the cli_token first, stripped, when present" do
+      without_env("SLACK_STATUS_TOKEN_WORK", "SLACK_SECRET_TOKEN") do
+        result = described_class.call(profile: "work", cli_token: "  xoxp-cli  ", config_path: "/no/such.yml")
+
+        expect(result).to eq(token: "xoxp-cli", source: "cli:--token", profile: "work")
+      end
+    end
+
+    it "returns the profile-scoped ENV var when there is no cli_token" do
+      without_env("SLACK_SECRET_TOKEN") do
+        with_env("SLACK_STATUS_TOKEN_WORK", "xoxp-env") do
+          result = described_class.call(profile: "work", config_path: "/no/such.yml")
+
+          expect(result).to eq(token: "xoxp-env", source: "env:SLACK_STATUS_TOKEN_WORK", profile: "work")
+        end
+      end
+    end
+
+    it "reads from the configured backend when neither cli_token nor ENV are set" do
+      without_env("SLACK_STATUS_TOKEN_WORK", "SLACK_SECRET_TOKEN") do
+        with_tmp_config do |path:, dir:|
+          token_path = File.join(dir, "work.token")
+          write_token_file(token_path, "xoxp-file")
+          config = build_config(profiles: {
+            "work" => { "storage_backend" => "file", "backend_options" => { "file" => { "path" => token_path } } }
+          })
+          SlackStatusCli::Tokens::Commands::WriteConfig.call(config: config, path: path)
+
+          result = described_class.call(profile: "work", config_path: path)
+
+          expect(result).to eq(token: "xoxp-file", source: "File", profile: "work")
+        end
+      end
+    end
+
+    it "honors the backend chosen by merged settings (profile overrides global)" do
+      without_env("SLACK_STATUS_TOKEN_WORK", "SLACK_SECRET_TOKEN") do
+        with_tmp_config do |path:, dir:|
+          token_path = File.join(dir, "work.token")
+          write_token_file(token_path, "xoxp-from-file")
+          config = build_config(
+            global: { "storage_backend" => "env" },
+            profiles: {
+              "work" => { "storage_backend" => "file", "backend_options" => { "file" => { "path" => token_path } } }
+            }
+          )
+          SlackStatusCli::Tokens::Commands::WriteConfig.call(config: config, path: path)
+
+          result = described_class.call(profile: "work", config_path: path)
+
+          expect(result[:token]).to eq("xoxp-from-file")
+        end
+      end
+    end
+
+    it "raises NotFoundError carrying the friendly NotFoundMessage when nothing resolves" do
+      without_env("SLACK_STATUS_TOKEN_GHOST", "SLACK_SECRET_TOKEN") do
+        expect { described_class.call(profile: "ghost", config_path: "/no/such.yml") }
+          .to raise_error(SlackStatusCli::Tokens::Errors::NotFoundError, /No Slack token found for profile 'ghost'/)
+      end
+    end
+
+    it "falls back to SLACK_SECRET_TOKEN only for the unconfigured default profile" do
+      without_env("SLACK_STATUS_TOKEN_DEFAULT") do
+        with_env("SLACK_SECRET_TOKEN", "xoxp-legacy") do
+          result = described_class.call(profile: "default", config_path: "/no/such.yml")
+
+          expect(result).to eq(token: "xoxp-legacy", source: "env:SLACK_SECRET_TOKEN", profile: "default")
+        end
+      end
+    end
+
+    it "ignores SLACK_SECRET_TOKEN for a non-default profile" do
+      without_env("SLACK_STATUS_TOKEN_WORK") do
+        with_env("SLACK_SECRET_TOKEN", "xoxp-legacy") do
+          expect { described_class.call(profile: "work", config_path: "/no/such.yml") }
+            .to raise_error(SlackStatusCli::Tokens::Errors::NotFoundError)
+        end
+      end
+    end
+
+    it "raises ConfigError for an unknown storage_backend" do
+      without_env("SLACK_STATUS_TOKEN_WORK", "SLACK_SECRET_TOKEN") do
+        with_tmp_config do |path:, **|
+          config = build_config(profiles: { "work" => { "storage_backend" => "bogus" } })
+          SlackStatusCli::Tokens::Commands::WriteConfig.call(config: config, path: path)
+
+          expect { described_class.call(profile: "work", config_path: path) }
+            .to raise_error(SlackStatusCli::Tokens::Errors::ConfigError, /bogus/)
+        end
+      end
+    end
+  end
+end

--- a/spec/slack_status_cli/tokens/queries/resolve_token_spec.rb
+++ b/spec/slack_status_cli/tokens/queries/resolve_token_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe SlackStatusCli::Tokens::Queries::ResolveToken do
     keys.each { |key| ENV.delete(key) }
     yield
   ensure
-    saved.each { |key, had, old| ENV[key] = old if had }
+    saved.each { |key, had, old| had ? ENV[key] = old : ENV.delete(key) }
   end
 
   def write_token_file(path, contents)


### PR DESCRIPTION
Closes #28

## Purpose
Extracts the Tokens pod's resolution layer from the legacy `lib/token_resolver.rb` into five focused Callables: the precedence walker (`ResolveToken`), the token writer (`WriteToken`), and three pure helpers (`EnvVarName`, `ProfileExplicitlyConfigured`, `NotFoundMessage`). The legacy `SLACK_SECRET_TOKEN` fallback (default profile only, no backend configured) is preserved as documented behavior rather than dropped.

## Test plan
- [x] `bundle exec rspec spec/slack_status_cli/tokens/queries/ spec/slack_status_cli/tokens/commands/write_token_spec.rb` green
- [x] `ResolveToken` covers all four precedence levels (cli / env / backend / raise) plus the legacy fallback
- [x] Full suite green (250 examples, 0 failures)
- [x] Draft PR opened

## Migrations
None.

## Platform
Tokens pod (refactor, extraction phase).

## Commit plan
1. feat(tokens-queries): Add EnvVarName Callable + spec
2. feat(tokens-queries): Add ProfileExplicitlyConfigured Callable + spec
3. feat(tokens-queries): Add NotFoundMessage Callable + spec
4. feat(tokens-queries): Add ResolveToken precedence walker + spec
5. feat(tokens-commands): Add WriteToken Callable + spec

## Follow-up
The name->backend-class map is duplicated in `ResolveToken` and `WriteToken`; a shared `BackendFor` query is a candidate tidy-up (pairs well with T4.5 cleanup).

Made with [Cursor](https://cursor.com)