### PR TITLE
feat(oauth): Extract OAuth pure queries (Errors + AuthorizeUrl + HandleCallbackRequest)

### DIFF
--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -68,6 +68,10 @@ module SlackStatusCli
     end
   end
 
+  module Oauth
+    autoload :Errors, "slack_status_cli/oauth/errors"
+  end
+
   module Music
     autoload :Constants, "slack_status_cli/music/constants"
 

--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -73,6 +73,7 @@ module SlackStatusCli
 
     module Queries
       autoload :AuthorizeUrl, "slack_status_cli/oauth/queries/authorize_url"
+      autoload :HandleCallbackRequest, "slack_status_cli/oauth/queries/handle_callback_request"
     end
   end
 

--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -70,6 +70,10 @@ module SlackStatusCli
 
   module Oauth
     autoload :Errors, "slack_status_cli/oauth/errors"
+
+    module Queries
+      autoload :AuthorizeUrl, "slack_status_cli/oauth/queries/authorize_url"
+    end
   end
 
   module Music

--- a/lib/slack_status_cli/oauth/errors.rb
+++ b/lib/slack_status_cli/oauth/errors.rb
@@ -1,0 +1,13 @@
+module SlackStatusCli
+  module Oauth
+    # OAuth install-flow error hierarchy. The Oauth pod owns its own failure
+    # vocabulary, mirroring the Tokens pod.
+    module Errors
+      class Error < StandardError; end
+      class StateMismatch < Error; end
+      class Timeout < Error; end
+      class ExchangeFailed < Error; end
+      class PortBusy < Error; end
+    end
+  end
+end

--- a/lib/slack_status_cli/oauth/queries/authorize_url.rb
+++ b/lib/slack_status_cli/oauth/queries/authorize_url.rb
@@ -1,0 +1,37 @@
+require "uri"
+
+module SlackStatusCli
+  module Oauth
+    module Queries
+      # Pure builder for Slack's OAuth authorize URL. Joins the requested user
+      # scopes with commas and form-encodes every param, so the redirect_uri is
+      # percent-encoded and the caller never has to assemble the query by hand.
+      class AuthorizeUrl
+        extend Callable
+
+        ENDPOINT = "https://slack.com/oauth/v2/authorize".freeze
+
+        def initialize(client_id:, redirect_uri:, scopes:, state:)
+          @client_id = client_id
+          @redirect_uri = redirect_uri
+          @scopes = scopes
+          @state = state
+        end
+
+        def call
+          params = {
+            client_id: client_id,
+            user_scope: Array(scopes).join(","),
+            redirect_uri: redirect_uri,
+            state: state
+          }
+          "#{ENDPOINT}?#{URI.encode_www_form(params)}"
+        end
+
+        private
+
+        attr_reader :client_id, :redirect_uri, :scopes, :state
+      end
+    end
+  end
+end

--- a/lib/slack_status_cli/oauth/queries/handle_callback_request.rb
+++ b/lib/slack_status_cli/oauth/queries/handle_callback_request.rb
@@ -1,0 +1,88 @@
+require "cgi"
+
+module SlackStatusCli
+  module Oauth
+    module Queries
+      # Pure extract of the WEBrick mount_proc body: takes the redirect query
+      # params and the expected CSRF state, then returns the payload + HTTP
+      # status the one-shot listener should serve. Slack error wins first, then
+      # the state guard, then the missing-code guard, else success.
+      class HandleCallbackRequest
+        extend Callable
+
+        def initialize(params:, expected_state:)
+          @params = params || {}
+          @expected_state = expected_state
+        end
+
+        def call
+          return error_result(slack_error) if slack_error
+          return error_result("state_mismatch") unless state_matches?
+          return error_result("missing_code") if blank?(code)
+
+          {
+            code: code,
+            state: params["state"],
+            error: nil,
+            status: 200,
+            body: success_body
+          }
+        end
+
+        private
+
+        attr_reader :params, :expected_state
+
+        def slack_error
+          value = params["error"]
+          value unless blank?(value)
+        end
+
+        def state_matches?
+          params["state"] == expected_state
+        end
+
+        def code
+          params["code"]
+        end
+
+        def error_result(error)
+          {
+            code: nil,
+            state: params["state"],
+            error: error,
+            status: 400,
+            body: error_body(error)
+          }
+        end
+
+        def blank?(value)
+          value.nil? || value.to_s.empty?
+        end
+
+        def success_body
+          <<~HTML
+            <!doctype html>
+            <html><head><meta charset="utf-8"><title>slack-status-cli</title></head>
+            <body style="font-family: -apple-system, system-ui, sans-serif; padding: 2rem; max-width: 36rem; margin: 0 auto;">
+              <h1>✅ Slack token received</h1>
+              <p>You can close this tab. Return to your terminal to finish setup.</p>
+            </body></html>
+          HTML
+        end
+
+        def error_body(reason)
+          <<~HTML
+            <!doctype html>
+            <html><head><meta charset="utf-8"><title>slack-status-cli</title></head>
+            <body style="font-family: -apple-system, system-ui, sans-serif; padding: 2rem; max-width: 36rem; margin: 0 auto;">
+              <h1>❌ OAuth failed</h1>
+              <p>#{CGI.escapeHTML(reason.to_s)}</p>
+              <p>Return to your terminal for next steps.</p>
+            </body></html>
+          HTML
+        end
+      end
+    end
+  end
+end

--- a/lib/slack_status_cli/oauth/queries/handle_callback_request.rb
+++ b/lib/slack_status_cli/oauth/queries/handle_callback_request.rb
@@ -16,9 +16,9 @@ module SlackStatusCli
         end
 
         def call
-          return error_result(slack_error) if slack_error
-          return error_result("state_mismatch") unless state_matches?
-          return error_result("missing_code") if blank?(code)
+          return error_result(slack_error, "Slack returned error=#{slack_error}") if slack_error
+          return error_result("state_mismatch", "OAuth state mismatch (CSRF guard)") unless state_matches?
+          return error_result("missing_code", "OAuth callback missing `code`") if blank?(code)
 
           {
             code: code,
@@ -46,13 +46,15 @@ module SlackStatusCli
           params["code"]
         end
 
-        def error_result(error)
+        # `error` stays the machine-friendly token for programmatic handling;
+        # `message` is the human-readable text rendered into the HTML page.
+        def error_result(error, message)
           {
             code: nil,
             state: params["state"],
             error: error,
             status: 400,
-            body: error_body(error)
+            body: error_body(message)
           }
         end
 

--- a/spec/slack_status_cli/oauth/errors_spec.rb
+++ b/spec/slack_status_cli/oauth/errors_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Oauth::Errors do
+  describe "Error" do
+    it "is a subclass of StandardError" do
+      expect(described_class::Error.ancestors).to include(StandardError)
+    end
+  end
+
+  describe "the specialized errors" do
+    it "all descend from Errors::Error" do
+      [
+        described_class::StateMismatch,
+        described_class::Timeout,
+        described_class::ExchangeFailed,
+        described_class::PortBusy
+      ].each do |klass|
+        expect(klass.ancestors).to include(described_class::Error)
+      end
+    end
+  end
+end

--- a/spec/slack_status_cli/oauth/queries/authorize_url_spec.rb
+++ b/spec/slack_status_cli/oauth/queries/authorize_url_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+require "uri"
+
+RSpec.describe SlackStatusCli::Oauth::Queries::AuthorizeUrl do
+  describe ".call" do
+    let(:url) do
+      described_class.call(
+        client_id: "123.456",
+        redirect_uri: "http://localhost:53682/callback",
+        scopes: %w[users.profile:write emoji:read],
+        state: "abc123"
+      )
+    end
+
+    def params(raw)
+      URI.decode_www_form(URI(raw).query).to_h
+    end
+
+    it "points at Slack's oauth/v2/authorize endpoint" do
+      expect(url).to start_with("https://slack.com/oauth/v2/authorize?")
+    end
+
+    it "includes the given client_id" do
+      expect(params(url)).to include("client_id" => "123.456")
+    end
+
+    it "percent-encodes the redirect_uri in the raw query string" do
+      expect(url).to include("redirect_uri=http%3A%2F%2Flocalhost%3A53682%2Fcallback")
+    end
+
+    it "round-trips the redirect_uri when the query is decoded" do
+      expect(params(url)).to include("redirect_uri" => "http://localhost:53682/callback")
+    end
+
+    it "joins scopes with commas in the user_scope param" do
+      expect(params(url)).to include("user_scope" => "users.profile:write,emoji:read")
+    end
+
+    it "includes the state param" do
+      expect(params(url)).to include("state" => "abc123")
+    end
+  end
+end

--- a/spec/slack_status_cli/oauth/queries/handle_callback_request_spec.rb
+++ b/spec/slack_status_cli/oauth/queries/handle_callback_request_spec.rb
@@ -1,0 +1,83 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Oauth::Queries::HandleCallbackRequest do
+  describe ".call" do
+    let(:state) { "expected-state-123" }
+
+    context "with a valid code + matching state" do
+      let(:result) do
+        described_class.call(
+          params: build_callback_params(code: "auth-code-1", state: state),
+          expected_state: state
+        )
+      end
+
+      it "returns the code, matching state, and no error" do
+        expect(result).to include(code: "auth-code-1", state: state, error: nil)
+      end
+
+      it "serves HTTP 200" do
+        expect(result[:status]).to eq(200)
+      end
+
+      it "serves the success body" do
+        expect(result[:body]).to include("Slack token received")
+      end
+    end
+
+    context "with a state mismatch" do
+      let(:result) do
+        described_class.call(
+          params: build_callback_params(code: "auth-code-1", state: "attacker-state"),
+          expected_state: state
+        )
+      end
+
+      it "returns a state_mismatch error with HTTP 400" do
+        expect(result).to include(error: "state_mismatch", status: 400)
+      end
+
+      it "withholds the code" do
+        expect(result[:code]).to be_nil
+      end
+
+      it "serves the error body" do
+        expect(result[:body]).to include("OAuth failed")
+      end
+    end
+
+    context "with an error param from Slack" do
+      let(:result) do
+        described_class.call(
+          params: build_callback_params(error: "access_denied", code: nil, state: state),
+          expected_state: state
+        )
+      end
+
+      it "passes the Slack error through with HTTP 400" do
+        expect(result).to include(error: "access_denied", status: 400)
+      end
+
+      it "serves the error body" do
+        expect(result[:body]).to include("OAuth failed")
+      end
+    end
+
+    context "with missing code" do
+      let(:result) do
+        described_class.call(
+          params: build_callback_params(code: nil, state: state),
+          expected_state: state
+        )
+      end
+
+      it "returns a missing_code error with HTTP 400" do
+        expect(result).to include(error: "missing_code", status: 400)
+      end
+
+      it "serves the error body" do
+        expect(result[:body]).to include("OAuth failed")
+      end
+    end
+  end
+end

--- a/spec/slack_status_cli/oauth/queries/handle_callback_request_spec.rb
+++ b/spec/slack_status_cli/oauth/queries/handle_callback_request_spec.rb
@@ -41,8 +41,9 @@ RSpec.describe SlackStatusCli::Oauth::Queries::HandleCallbackRequest do
         expect(result[:code]).to be_nil
       end
 
-      it "serves the error body" do
-        expect(result[:body]).to include("OAuth failed")
+      it "serves a human-readable error body, not the machine token" do
+        expect(result[:body]).to include("OAuth failed", "state mismatch")
+        expect(result[:body]).not_to include("state_mismatch")
       end
     end
 
@@ -58,8 +59,8 @@ RSpec.describe SlackStatusCli::Oauth::Queries::HandleCallbackRequest do
         expect(result).to include(error: "access_denied", status: 400)
       end
 
-      it "serves the error body" do
-        expect(result[:body]).to include("OAuth failed")
+      it "names the Slack error in the human-readable body" do
+        expect(result[:body]).to include("OAuth failed", "Slack returned error=access_denied")
       end
     end
 
@@ -75,8 +76,9 @@ RSpec.describe SlackStatusCli::Oauth::Queries::HandleCallbackRequest do
         expect(result).to include(error: "missing_code", status: 400)
       end
 
-      it "serves the error body" do
-        expect(result[:body]).to include("OAuth failed")
+      it "serves a human-readable error body, not the machine token" do
+        expect(result[:body]).to include("OAuth failed", "missing `code`")
+        expect(result[:body]).not_to include("missing_code")
       end
     end
   end

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -7,6 +7,14 @@ module Factories
     { "global" => global, "profiles" => profiles }
   end
 
+  def build_callback_params(code: "auth-code", state: "state", error: nil)
+    params = {}
+    params["code"] = code unless code.nil?
+    params["state"] = state unless state.nil?
+    params["error"] = error unless error.nil?
+    params
+  end
+
   def build_slack_auth_response(team: "Phoenix HQ", user: "efmcuiti", ok: true)
     {
       "ok" => ok,


### PR DESCRIPTION
Closes #30

## Purpose
First task in Epic 5 (OAuth pod). Extracts the three pure, testable callables out of `lib/oauth_helper.rb`: the `Oauth::Errors` module, `Queries::AuthorizeUrl` (pure authorize-URL builder), and `Queries::HandleCallbackRequest` (the testable extract of `#wait_for_callback`'s `mount_proc` body). The WEBrick orchestrator stays as untested glue for T5.3.

## Test plan
- [x] `Oauth::Errors` exposes Error/StateMismatch/Timeout/ExchangeFailed/PortBusy
- [x] `AuthorizeUrl` builds the authorize URL (endpoint, client_id, comma-joined scopes, percent-encoded redirect_uri, state)
- [x] `HandleCallbackRequest` covers state-mismatch, Slack-error, missing-code, and success branches
- [x] Full suite green (`bundle exec rspec` — 271 examples, 0 failures)
- [x] Draft PR opened

## Commit plan
1. feat(oauth): Add Oauth::Errors module + spec
2. feat(oauth-queries): Add AuthorizeUrl Callable + spec
3. feat(oauth-queries): Add HandleCallbackRequest Callable + spec

Made with [Cursor](https://cursor.com)