### PR TITLE
feat(oauth): Extract OAuth commands + views (ExchangeCode + SuccessPage + ErrorPage)

### DIFF
--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -82,6 +82,7 @@ module SlackStatusCli
 
     module Views
       autoload :SuccessPage, "slack_status_cli/oauth/views/success_page"
+      autoload :ErrorPage, "slack_status_cli/oauth/views/error_page"
     end
   end
 

--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -75,6 +75,10 @@ module SlackStatusCli
       autoload :AuthorizeUrl, "slack_status_cli/oauth/queries/authorize_url"
       autoload :HandleCallbackRequest, "slack_status_cli/oauth/queries/handle_callback_request"
     end
+
+    module Commands
+      autoload :ExchangeCode, "slack_status_cli/oauth/commands/exchange_code"
+    end
   end
 
   module Music

--- a/lib/slack_status_cli.rb
+++ b/lib/slack_status_cli.rb
@@ -79,6 +79,10 @@ module SlackStatusCli
     module Commands
       autoload :ExchangeCode, "slack_status_cli/oauth/commands/exchange_code"
     end
+
+    module Views
+      autoload :SuccessPage, "slack_status_cli/oauth/views/success_page"
+    end
   end
 
   module Music

--- a/lib/slack_status_cli/oauth/commands/exchange_code.rb
+++ b/lib/slack_status_cli/oauth/commands/exchange_code.rb
@@ -1,0 +1,65 @@
+require "json"
+require "net/http"
+require "uri"
+
+module SlackStatusCli
+  module Oauth
+    module Commands
+      # Exchanges the authorization code for an xoxp- user token via Slack's
+      # oauth.v2.access endpoint, authenticating with HTTP Basic
+      # (client_id:client_secret). Raises ExchangeFailed on any non-200, an
+      # ok:false payload, or a response that carries no access_token.
+      class ExchangeCode
+        extend Callable
+
+        ACCESS_URL = "https://slack.com/api/oauth.v2.access".freeze
+
+        def initialize(code:, client_id:, client_secret:, redirect_uri:)
+          @code = code
+          @client_id = client_id
+          @client_secret = client_secret
+          @redirect_uri = redirect_uri
+        end
+
+        def call
+          response = post
+          unless response.is_a?(Net::HTTPSuccess)
+            raise Errors::ExchangeFailed, "Slack HTTP #{response.code}: #{response.body.to_s.strip[0, 200]}"
+          end
+
+          payload = JSON.parse(response.body)
+          raise Errors::ExchangeFailed, "oauth.v2.access error=#{payload['error']}" unless payload["ok"]
+
+          user = payload["authed_user"] || {}
+          token = user["access_token"]
+          if token.nil? || token.empty?
+            raise Errors::ExchangeFailed, "oauth.v2.access returned no authed_user.access_token"
+          end
+
+          {
+            token: token,
+            scope: user["scope"],
+            user_id: user["id"],
+            team_id: payload.dig("team", "id"),
+            team_name: payload.dig("team", "name")
+          }
+        end
+
+        private
+
+        attr_reader :code, :client_id, :client_secret, :redirect_uri
+
+        def post
+          uri = URI(ACCESS_URL)
+          request = Net::HTTP::Post.new(uri)
+          request.basic_auth(client_id, client_secret)
+          request.set_form_data("code" => code, "redirect_uri" => redirect_uri)
+
+          Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+            http.request(request)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/slack_status_cli/oauth/commands/exchange_code.rb
+++ b/lib/slack_status_cli/oauth/commands/exchange_code.rb
@@ -24,7 +24,7 @@ module SlackStatusCli
         def call
           response = post
           unless response.is_a?(Net::HTTPSuccess)
-            raise Errors::ExchangeFailed, "Slack HTTP #{response.code}: #{response.body.to_s.strip[0, 200]}"
+            raise Errors::ExchangeFailed, "Slack HTTP #{response.code}: #{scrubbed_excerpt(response.body)}"
           end
 
           payload = JSON.parse(response.body)
@@ -48,6 +48,12 @@ module SlackStatusCli
         private
 
         attr_reader :code, :client_id, :client_secret, :redirect_uri
+
+        # Slack's response body can carry xox*-tokens, so scrub before it ever
+        # reaches an exception message that might land in logs/STDERR.
+        def scrubbed_excerpt(body)
+          SecretScrubber.call(text: body.to_s.strip).to_s[0, 200]
+        end
 
         def post
           uri = URI(ACCESS_URL)

--- a/lib/slack_status_cli/oauth/views/error_page.rb
+++ b/lib/slack_status_cli/oauth/views/error_page.rb
@@ -1,0 +1,35 @@
+require "cgi"
+
+module SlackStatusCli
+  module Oauth
+    module Views
+      # The HTML the one-shot WEBrick listener serves when the callback fails.
+      # The reason is HTML-escaped so a Slack-supplied or attacker-influenced
+      # value can never inject markup. Kept byte-identical to the error copy
+      # HandleCallbackRequest inlines today (T5.3 will delegate here).
+      class ErrorPage
+        extend Callable
+
+        def initialize(reason:)
+          @reason = reason
+        end
+
+        def call
+          <<~HTML
+            <!doctype html>
+            <html><head><meta charset="utf-8"><title>slack-status-cli</title></head>
+            <body style="font-family: -apple-system, system-ui, sans-serif; padding: 2rem; max-width: 36rem; margin: 0 auto;">
+              <h1>❌ OAuth failed</h1>
+              <p>#{CGI.escapeHTML(reason.to_s)}</p>
+              <p>Return to your terminal for next steps.</p>
+            </body></html>
+          HTML
+        end
+
+        private
+
+        attr_reader :reason
+      end
+    end
+  end
+end

--- a/lib/slack_status_cli/oauth/views/success_page.rb
+++ b/lib/slack_status_cli/oauth/views/success_page.rb
@@ -1,0 +1,24 @@
+module SlackStatusCli
+  module Oauth
+    module Views
+      # The HTML the one-shot WEBrick listener serves after a successful token
+      # exchange. Kept byte-identical to the success copy HandleCallbackRequest
+      # inlines today, so T5.3 can make the handler delegate here without the
+      # page drifting.
+      class SuccessPage
+        extend Callable
+
+        def call
+          <<~HTML
+            <!doctype html>
+            <html><head><meta charset="utf-8"><title>slack-status-cli</title></head>
+            <body style="font-family: -apple-system, system-ui, sans-serif; padding: 2rem; max-width: 36rem; margin: 0 auto;">
+              <h1>✅ Slack token received</h1>
+              <p>You can close this tab. Return to your terminal to finish setup.</p>
+            </body></html>
+          HTML
+        end
+      end
+    end
+  end
+end

--- a/spec/slack_status_cli/oauth/commands/exchange_code_spec.rb
+++ b/spec/slack_status_cli/oauth/commands/exchange_code_spec.rb
@@ -1,0 +1,69 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Oauth::Commands::ExchangeCode do
+  describe ".call" do
+    let(:endpoint) { "https://slack.com/api/oauth.v2.access" }
+    let(:args) do
+      {
+        code: "auth-code-1",
+        client_id: "123.456",
+        client_secret: "s3cr3t",
+        redirect_uri: "http://localhost:53682/callback"
+      }
+    end
+
+    it "POSTs the form-encoded code and redirect_uri to oauth.v2.access" do
+      stub = stub_request(:post, endpoint)
+        .with(body: { "code" => "auth-code-1", "redirect_uri" => "http://localhost:53682/callback" })
+        .to_return(status: 200, body: build_oauth_access_response.to_json)
+
+      described_class.call(**args)
+
+      expect(stub).to have_been_requested
+    end
+
+    it "authenticates with HTTP Basic using the client id and secret" do
+      stub = stub_request(:post, endpoint)
+        .with(basic_auth: ["123.456", "s3cr3t"])
+        .to_return(status: 200, body: build_oauth_access_response.to_json)
+
+      described_class.call(**args)
+
+      expect(stub).to have_been_requested
+    end
+
+    it "returns the token and identity fields on ok:true" do
+      body = build_oauth_access_response(
+        token: "xoxp-real",
+        scope: "users.profile:write",
+        user_id: "U999",
+        team_id: "T999",
+        team_name: "Phoenix HQ"
+      )
+      stub_request(:post, endpoint).to_return(status: 200, body: body.to_json)
+
+      expect(described_class.call(**args)).to eq(
+        token: "xoxp-real",
+        scope: "users.profile:write",
+        user_id: "U999",
+        team_id: "T999",
+        team_name: "Phoenix HQ"
+      )
+    end
+
+    it "raises ExchangeFailed naming the Slack error on ok:false" do
+      stub_request(:post, endpoint)
+        .to_return(status: 200, body: { "ok" => false, "error" => "invalid_code" }.to_json)
+
+      expect { described_class.call(**args) }
+        .to raise_error(SlackStatusCli::Oauth::Errors::ExchangeFailed, /invalid_code/)
+    end
+
+    it "raises ExchangeFailed on a non-200 HTTP status" do
+      stub_request(:post, endpoint).to_return(status: 502, body: "bad gateway")
+
+      expect { described_class.call(**args) }
+        .to raise_error(SlackStatusCli::Oauth::Errors::ExchangeFailed, /502/)
+    end
+  end
+end

--- a/spec/slack_status_cli/oauth/commands/exchange_code_spec.rb
+++ b/spec/slack_status_cli/oauth/commands/exchange_code_spec.rb
@@ -66,6 +66,18 @@ RSpec.describe SlackStatusCli::Oauth::Commands::ExchangeCode do
         .to raise_error(SlackStatusCli::Oauth::Errors::ExchangeFailed, /502/)
     end
 
+    it "scrubs Slack tokens out of the non-200 error message" do
+      leaky = '{"note":"leaked xoxp-1234567890-SUPERSECRETVALUE9999 oops"}'
+      stub_request(:post, endpoint).to_return(status: 500, body: leaky)
+
+      expect { described_class.call(**args) }.to raise_error(
+        SlackStatusCli::Oauth::Errors::ExchangeFailed
+      ) do |error|
+        expect(error.message).to include("xox?-…9999")
+        expect(error.message).not_to include("xoxp-1234567890-SUPERSECRETVALUE9999")
+      end
+    end
+
     it "raises ExchangeFailed when ok:true but the access_token is missing" do
       stub_request(:post, endpoint)
         .to_return(status: 200, body: build_oauth_access_response(token: nil).to_json)

--- a/spec/slack_status_cli/oauth/commands/exchange_code_spec.rb
+++ b/spec/slack_status_cli/oauth/commands/exchange_code_spec.rb
@@ -65,5 +65,21 @@ RSpec.describe SlackStatusCli::Oauth::Commands::ExchangeCode do
       expect { described_class.call(**args) }
         .to raise_error(SlackStatusCli::Oauth::Errors::ExchangeFailed, /502/)
     end
+
+    it "raises ExchangeFailed when ok:true but the access_token is missing" do
+      stub_request(:post, endpoint)
+        .to_return(status: 200, body: build_oauth_access_response(token: nil).to_json)
+
+      expect { described_class.call(**args) }
+        .to raise_error(SlackStatusCli::Oauth::Errors::ExchangeFailed, /no authed_user.access_token/)
+    end
+
+    it "raises ExchangeFailed when ok:true but the access_token is blank" do
+      stub_request(:post, endpoint)
+        .to_return(status: 200, body: build_oauth_access_response(token: "").to_json)
+
+      expect { described_class.call(**args) }
+        .to raise_error(SlackStatusCli::Oauth::Errors::ExchangeFailed, /no authed_user.access_token/)
+    end
   end
 end

--- a/spec/slack_status_cli/oauth/views/error_page_spec.rb
+++ b/spec/slack_status_cli/oauth/views/error_page_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Oauth::Views::ErrorPage do
+  describe ".call" do
+    it "renders the given reason in the page" do
+      expect(described_class.call(reason: "OAuth state mismatch (CSRF guard)"))
+        .to include("OAuth state mismatch (CSRF guard)")
+    end
+
+    it "HTML-escapes the reason so it cannot inject markup" do
+      html = described_class.call(reason: "<script>alert(1)</script>")
+
+      expect(html).to include("&lt;script&gt;")
+      expect(html).not_to include("<script>alert(1)</script>")
+    end
+
+    it "returns a complete HTML document" do
+      html = described_class.call(reason: "boom")
+      expect(html).to include("<html").and include("</html>")
+    end
+  end
+end

--- a/spec/slack_status_cli/oauth/views/success_page_spec.rb
+++ b/spec/slack_status_cli/oauth/views/success_page_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+RSpec.describe SlackStatusCli::Oauth::Views::SuccessPage do
+  describe ".call" do
+    it "tells the user the token was received" do
+      expect(described_class.call).to include("Slack token received")
+    end
+
+    it "returns a complete HTML document" do
+      html = described_class.call
+      expect(html).to include("<html").and include("</html>")
+    end
+  end
+end

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -15,6 +15,14 @@ module Factories
     params
   end
 
+  def build_oauth_access_response(ok: true, token: "xoxp-user-token", scope: "users.profile:write,emoji:read", user_id: "U0123456789", team_id: "T0123456789", team_name: "Phoenix HQ")
+    {
+      "ok" => ok,
+      "authed_user" => { "access_token" => token, "scope" => scope, "id" => user_id },
+      "team" => { "id" => team_id, "name" => team_name }
+    }
+  end
+
   def build_slack_auth_response(team: "Phoenix HQ", user: "efmcuiti", ok: true)
     {
       "ok" => ok,


### PR DESCRIPTION
Closes #31

## Purpose
Second task in Epic 5 (OAuth pod). Introduces the new `SlackStatusCli::Oauth` surfaces mirrored from `lib/oauth_helper.rb`: the side-effecting `Commands::ExchangeCode` (the HTTP Basic POST to Slack's `oauth.v2.access` that swaps the auth code for an `xoxp-` user token) and the two HTML response views (`Views::SuccessPage`, `Views::ErrorPage`). The view copy is kept byte-identical to what `HandleCallbackRequest` inlines today, so T5.3 can make the WEBrick handler delegate to these without the pages drifting.

**Scope note (extraction, not removal):** this PR only *adds* the new Callables; `OAuthHelper#exchange_code`/`#success_page`/`#error_page` and the WEBrick orchestration are intentionally left untouched here. Wiring the orchestrator to these surfaces and deleting `lib/oauth_helper.rb` is the explicit scope of **T5.3 (#32)**, which is blocked on this PR. The temporary duplication is by design and lives for exactly one task.

## Test plan
- [x] `ExchangeCode` POSTs form-encoded params with HTTP Basic auth and returns `{ token:, scope:, user_id:, team_id:, team_name: }` on `ok:true`
- [x] `ExchangeCode` raises `ExchangeFailed` on `ok:false` (slack error) and on non-200 status
- [x] `SuccessPage` / `ErrorPage` return complete HTML documents
- [x] `ErrorPage` HTML-escapes the reason (injection guard)
- [x] Full suite green (`bundle exec rspec` — 281 examples, 0 failures)
- [x] Draft PR opened

## Commit plan
1. feat(oauth-commands): Add ExchangeCode Callable + WebMock spec
2. feat(oauth-views): Add SuccessPage Callable + spec
3. feat(oauth-views): Add ErrorPage Callable + spec

Made with [Cursor](https://cursor.com)
